### PR TITLE
Retain nwis 01481500

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -48,7 +48,7 @@ site_tp_select <- c("ST","ST-CA","SP")
 
 # Omit undesired sites
 # sites 01412350, 01484272 coded as site type "ST" but appear to be tidally-influenced
-omit_nwis_sites <- c("01412350","01484272", "01481500", "01477050", "01467200", "014670261", "01464600")
+omit_nwis_sites <- c("01412350","01484272", "01477050", "01467200", "014670261", "01464600")
 
 # Define USGS stat codes for continuous sites that only report daily statistics (https://help.waterdata.usgs.gov/stat_code) 
 stat_cd_select <- c("00001","00002","00003")


### PR DESCRIPTION
Addresses #50.

In #50, we could not identify a reason why [01481500](https://waterdata.usgs.gov/usa/nwis/uv?01481500) was characterized as tidal, so I removed that site from `omit_nwis_sites`. This change retains 01481500 in our data pipeline, and it is now included in our list of well-observed sites (now 14 sites; number of obs-days > 300). Note that I have not specified 01481500 within any of our train/test/val splits in this PR. 

