### PR TITLE
add new targets for moderately-observed sites

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -92,7 +92,9 @@ p2_targets_list <- list(
   # make list of "well-observed" sites
   tar_target(
    p2_well_observed_sites,
-   p2_sites_w_segs %>% filter(count_days_total > 300) %>% pull(site_id)
+   p2_sites_w_segs %>% 
+     filter(count_days_total > 300) %>% 
+     pull(site_id)
  ),
  
  # filter p1_reaches_sf to segments with "well-observed" sites
@@ -105,7 +107,15 @@ p2_targets_list <- list(
    p1_reaches_sf %>% filter(segidnat %in% well_obs_reach_ids)
    }
  ),
-  
+ 
+ # make list of "moderately-observed" sites
+ tar_target(
+   p2_med_observed_sites,
+   p2_sites_w_segs %>%
+     filter(count_days_nwis >= 100) %>%
+     pull(site_id)
+ ),
+
   # Estimate daily (normalized) max-light
   tar_target(
     p2_daily_max_light,

--- a/2_process.R
+++ b/2_process.R
@@ -115,15 +115,26 @@ p2_targets_list <- list(
      filter(count_days_nwis >= 100) %>%
      pull(site_id)
  ),
-
-  # Estimate daily (normalized) max-light
-  tar_target(
-    p2_daily_max_light,
-    { 
-    calc_seg_light_ratio(p2_well_observed_reaches, start_date = earliest_date, end_date = dummy_date)
-    },
-    pattern = map(p2_well_observed_reaches)
-  ),
+ 
+ # filter p1_reaches_sf to segments with "well-observed" sites
+ tar_target(   
+   p2_med_observed_reaches,
+   {
+     med_obs_reach_ids <- p2_sites_w_segs %>%
+       filter(site_id %in% p2_med_observed_sites) %>% 
+       pull(segidnat)
+     p1_reaches_sf %>% filter(segidnat %in% med_obs_reach_ids)
+   }
+ ),
+ 
+ # Estimate daily (normalized) max-light
+ tar_target(
+   p2_daily_max_light,
+   { 
+     calc_seg_light_ratio(p2_med_observed_reaches, start_date = earliest_date, end_date = dummy_date)
+   },
+   pattern = map(p2_med_observed_reaches)
+ ),
 
  # Filter daily metabolism estimates based on model diagnostics
  tar_target(

--- a/2_process/src/match_sites_reaches.R
+++ b/2_process/src/match_sites_reaches.R
@@ -31,10 +31,12 @@ get_site_flowlines <- function(reach_sf, sites, sites_crs, max_matches = 1, sear
     # get_flowline_index are in meters rather than degrees
     st_transform(5070)
   
-  sites_sf <- sites %>% rowwise() %>%
-    filter(across(c(lon, lat), ~ !is.na(.x))) %>%
+  sites_sf <- sites %>% 
+    rowwise() %>%
+    filter(!is.na(lon), !is.na(lat)) %>%
     mutate(Shape = list(st_point(c(lon, lat), dim = "XY"))) %>%
-    st_as_sf() %>% st_set_crs(sites_crs) %>%
+    st_as_sf() %>% 
+    st_set_crs(sites_crs) %>%
     st_transform(st_crs(reaches_nhd_fields)) %>%
     st_geometry()
   

--- a/2a_model.R
+++ b/2a_model.R
@@ -28,6 +28,13 @@ p2a_targets_list <- list(
     p2a_seg_attr_w_sites,
     match_site_ids_to_segs(p1_seg_attr_data, p2_sites_w_segs)
   ),
+  
+  # join the metab data with the DO observations
+  tar_target(
+    p2a_do_and_metab,
+    p2_daily_with_seg_ids %>%
+      full_join(p2_metab_filtered, by = c("site_id", "date"))
+  ),
 
   ## SPLIT SITES INTO (train) and (train and validation) ##
   # char vector of well-observed train sites
@@ -76,12 +83,8 @@ p2a_targets_list <- list(
         filter(site_id %in% p2a_trn_val_sites) %>%
         inner_join(p2a_seg_attr_w_sites, by = c("site_id", "seg_id_nat"))
 
-      # need to join the metab data with the DO observations. 
-      do_and_metab <- p2_daily_with_seg_ids %>%
-          full_join(p2_metab_filtered, by=c("site_id", "date"))
-
       inputs_and_outputs <- inputs %>%
-          left_join(do_and_metab, by=c("site_id", "date"))
+          left_join(p2a_do_and_metab, by=c("site_id", "date"))
       
       write_df_to_zarr(inputs_and_outputs, c("site_id", "date"), "2a_model/out/well_obs_io.zarr")
     },
@@ -141,80 +144,24 @@ p2a_targets_list <- list(
   
   
   ## CREATE EQUIVALENT TARGETS FOR "MODERATELY-OBSERVED SITES" ##
-  # char vector of moderately-observed train sites
+  # write input/output data to zarr for the medium-observed sites
   tar_target(
-    p2a_trn_sites_medobs,
-    p2_med_observed_sites[!(p2_med_observed_sites %in% val_sites) & !(p2_med_observed_sites %in% tst_sites)]
-  ),
-  
-  # char vector of moderately-observed val and training sites
-  tar_target(
-    p2a_trn_val_sites_medobs,
-    p2_med_observed_sites[(p2_med_observed_sites %in% p2a_trn_sites_medobs) | (p2_med_observed_sites %in% val_sites)]
-  ),
-  
-  # get moderately-observed sites that we use for trning, but also have data in the val time period
-  tar_target(
-    p2a_trn_sites_w_val_data_medobs,
-    p2_daily_with_seg_ids  %>%
-      filter(site_id %in% p2a_trn_val_sites_medobs,
-             !site_id %in% val_sites,
-             date >= val_start_date,
-             date < val_end_date) %>%
-      group_by(site_id) %>%
-      summarise(val_count = sum(!is.na(do_mean))) %>%
-      filter(val_count > 0) %>%
-      pull(site_id)
-  ),
-  
-  # moderately-observed sites that are trning sites but do not have data in val period
-  tar_target(
-    p2a_trn_only_medobs,
-    p2a_trn_sites_medobs[!p2a_trn_sites_medobs %in% p2a_trn_sites_w_val_data_medobs]
-  ),
-  
-  
-  ## WRITE OUT PARTITION INPUT AND OUTPUT DATA ##
-  # write trn met and seg attribute data to zarr
-  # note - I have to subset before passing to subset_and_write_zarr or else I
-  # get a memory error on the join
-  tar_target(
-    p2a_trn_inputs_medobs_zarr,
-    { 
-      trn_input <- p2a_met_data_w_sites %>%
-        filter(site_id %in% p2a_trn_sites_medobs) %>%
-        inner_join(p2a_seg_attr_w_sites, by = "site_id")
-      subset_and_write_zarr(trn_input, "2a_model/out/med_observed_trn_inputs.zarr")
+    p2a_med_obs_data,
+    {
+      inputs_med_obs <- p2a_met_data_w_sites %>%
+        # include all med-obs sites not in testing sites
+        filter(site_id %in% p2_med_observed_sites, 
+               !site_id %in% tst_sites) %>%
+        inner_join(p2a_seg_attr_w_sites, by = c("site_id","seg_id_nat"))
+      
+      inputs_and_outputs_med_obs <- inputs_med_obs %>%
+        left_join(p2a_do_and_metab, by = c("site_id", "date"))
+      
+      write_df_to_zarr(inputs_and_outputs_med_obs, c("site_id","date"),
+                       "2a_model/out/med_obs_io.zarr")
     },
-    format="file"
-  ),
-  
-  # write trn and val met and seg attribute data to zarr
-  # note - I have to subset before passing to subset_and_write_zarr or else I
-  # get a memory error on the join
-  tar_target(
-    p2a_trn_val_inputs_medobs_zarr,
-    { 
-      trn_input <- p2a_met_data_w_sites %>%
-        filter(site_id %in% p2a_trn_val_sites_medobs) %>%
-        inner_join(p2a_seg_attr_w_sites, by = "site_id")
-      subset_and_write_zarr(trn_input, "2a_model/out/med_observed_trn_inputs.zarr")
-    },
-    format="file"
-  ),
-  
-  # write trn do data to zarr
-  tar_target(
-    p2a_trn_do_medobs_zarr,
-    subset_and_write_zarr(p2_daily_with_seg_ids, "2a_model/out/med_observed_trn_do.zarr", p2a_trn_sites_medobs),
-    format="file"
-  ),
-  
-  # write trn and val do data to zarr
-  tar_target(
-    p2a_trn_val_do_medobs_zarr,
-    subset_and_write_zarr(p2_daily_with_seg_ids, "2a_model/out/med_observed_trn_do.zarr", p2a_trn_val_sites_medobs),
-    format="file"
+    format = "file"
   )
+  
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -62,7 +62,7 @@ earliest_date <- "1979-10-01"
 dummy_date <- "2021-12-19"
 
 # test and validation sites
-val_sites <- c("01472104", "01473500", "01481500")
+val_sites <- c("01472104", "01473500", "01481500","014721254")
 tst_sites <- c("01475530", "01475548")
 
 train_start_date <- '1980-01-01'

--- a/_targets.R
+++ b/_targets.R
@@ -62,7 +62,7 @@ earliest_date <- "1979-10-01"
 dummy_date <- "2021-12-19"
 
 # test and validation sites
-val_sites <- c("01472104", "01473500", "01481500","014721254")
+val_sites <- c("01472104", "01473500", "01481500")
 tst_sites <- c("01475530", "01475548")
 
 train_start_date <- '1980-01-01'


### PR DESCRIPTION
Addresses #73.

The code changes here add a new target, `p2_med_observed_sites` that indicates the NWIS sites with at least 100 observation-days. Up to this point we have only considered well-observed sites (>300 obs-days; n = 14). By lowering our criteria for the number of observations, we get 23 "moderately-observed" sites:

```
> p2_well_observed_sites
 [1] "01466500" "01472104" "01472119" "01473499" "01473500" "01473675" "01473780" "01474500" "01475530" "01475548" "01480617" "01480870" "01481000"
[14] "01481500"
> 
> p2_med_observed_sites
 [1] "01465798"  "01466500"  "01467042"  "01467048"  "01467086"  "01467087"  "01472104"  "01472119"  "014721254" "014721259" "01473499"  "01473500" 
[13] "01473675"  "01473780"  "01473900"  "01474000"  "01474500"  "01475530"  "01475548"  "01480617"  "01480870"  "01481000"  "01481500" 
> 
```


This PR also adds a new "medobs" version of all the targets in `2a_model.R` (using the same `val_sites` and `tst_sites` defined in `_targets.R` as before), so new zarr files get written to reflect these moderately-observed sites:

![network_diagram](https://user-images.githubusercontent.com/8785034/159706604-75b5a70e-807d-42d8-8881-4edc9741e358.png)

A couple questions:

- I've assumed we want to stick with the NWIS sites, but there are discrete sites that meet this new criteria (see #73). Do we want to include those in the training data?
- Incorporating the moderately-observed sites makes the `2a_model.R` file pretty bulky since we're essentially repeating targets. I would welcome any suggestions you have for how to clean this up, e.g. perhaps we could add a toggle that indicates whether we want to write the zarr files for well-observed vs. moderately-observed. We could also keep as is.
