### PR TITLE
77 reproduce preds

### DIFF
--- a/2a_model.R
+++ b/2a_model.R
@@ -115,6 +115,17 @@ p2a_targets_list <- list(
       subset_and_write_zarr(do_and_metab, "2a_model/out/well_observed_trn_val_targets.zarr", p2a_trn_val_sites)
     },
     format="file"
+  ),
+
+  # write prepped file to .npz
+  tar_target(
+    p2a_0_baseline_prepped,
+    prep_io_data(x_data_file = p2a_trn_inputs_zarr,
+                 y_data_file = p2a_trn_targets_zarr,
+                 config_dir = "2a_model/src/models/0_baseline_LSTM",
+                 out_file = "2a_model/out/models/0_baseline_LSTM/prepped.npz"),
+
+    format="file"
   )
 
 )

--- a/2a_model.R
+++ b/2a_model.R
@@ -95,7 +95,7 @@ p2a_targets_list <- list(
 
   # write trn do and metab data to zarr
   tar_target(
-    p2a_trn_do_zarr,
+    p2a_trn_targets_zarr,
     {
       # need to join the metab data with the DO observations. 
       do_and_metab <- p2_daily_with_seg_ids %>%
@@ -107,7 +107,7 @@ p2a_targets_list <- list(
 
   # write trn and val do and metab data to zarr
   tar_target(
-    p2a_trn_val_do_zarr,
+    p2a_trn_val_targets_zarr,
     {
       # need to join the metab data with the DO observations. 
       do_and_metab <- p2_daily_with_seg_ids %>%

--- a/2a_model.R
+++ b/2a_model.R
@@ -119,13 +119,31 @@ p2a_targets_list <- list(
 
   # write prepped file to .npz
   tar_target(
-    p2a_0_baseline_prepped,
+    p2a_model_ids,
+    c("0_baseline_LSTM")
+  ),
+
+  tar_target(
+    p2a_prepped,
+    {
+    dir.create(sprintf("2a_model/out/models/%s", p2a_model_ids), showWarnings = FALSE)
     prep_io_data(x_data_file = p2a_trn_inputs_zarr,
                  y_data_file = p2a_trn_targets_zarr,
-                 config_dir = "2a_model/src/models/0_baseline_LSTM",
-                 out_file = "2a_model/out/models/0_baseline_LSTM/prepped.npz"),
+                 config_dir = sprintf("2a_model/src/models/%s", p2a_model_ids),
+                 out_file = sprintf("2a_model/out/models/%s/prepped.npz", p2a_model_ids))
+    },
+    format="file",
+    pattern = map(p2a_model_ids)
+  ),
 
-    format="file"
+  tar_target(
+    p2a_metrics_files,
+    {
+    p2a_prepped
+    system(sprintf("snakemake -s 2a_model/src/models/%s/Snakefile -j4", p2a_model_ids))
+    sprintf("2a_model/out/models/%s/exp_overall_metrics.csv", p2a_model_ids)
+    },
+    format="file",
+    pattern = map(p2a_model_ids)
   )
-
 )

--- a/2a_model/src/model_ready_data_utils.R
+++ b/2a_model/src/model_ready_data_utils.R
@@ -61,3 +61,29 @@ subset_and_write_zarr <- function(df, out_zarr, sites_subset = NULL){
   out_zarr <- write_df_to_zarr(df, c("site_id", "date"), out_zarr)
   return(out_zarr)
 }
+
+
+prep_io_data <- function(x_data_file, y_data_file, config_dir, out_file){
+    reticulate::source_python("2a_model/src/models/river-dl/river_dl/preproc_utils.py")
+
+    config = yaml::read_yaml(file.path(config_dir, "config.yml"))
+    
+    prep_all_data(x_data_file=x_data_file,
+                  y_data_file=y_data_file,
+                  x_vars=config$x_vars,
+                  y_vars_finetune=config$y_vars,
+                  spatial_idx_name='site_id',
+                  time_idx_name='date',
+                  train_start_date=config$train_start_date,
+                  train_end_date=config$train_end_date,
+                  val_start_date=config$val_start_date,
+                  val_end_date=config$val_end_date,
+                  test_start_date=config$test_start_date,
+                  test_end_date=config$test_end_date,
+                  out_file=out_file,
+                  trn_offset = config$trn_offset,
+                  tst_val_offset = config$tst_val_offset)
+
+    return(out_file)
+}
+

--- a/2a_model/src/models/0_baseline_LSTM/Snakefile
+++ b/2a_model/src/models/0_baseline_LSTM/Snakefile
@@ -1,5 +1,6 @@
 from model import LSTMModel
 
+workdir: "2a_model/src/models/0_baseline_LSTM"
 configfile: "config.yml"
 
 out_dir = os.path.join(config['out_dir'], config['exp_name'])

--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -22,36 +22,11 @@ rule as_run_config:
         asRunConfig(config,output[0])
 
 
-rule prep_io_data:
-    input:
-        "../../../out/well_observed_trn_inputs.zarr",
-        "../../../out/well_observed_trn_targets.zarr",
-    output:
-        "{outdir}/nstates_{nstates}/rep_{rep}/prepped.npz"
-    run:
-        prep_all_data(
-                  x_data_file=input[0],
-                  y_data_file=input[1],
-                  x_vars=config['x_vars'],
-                  y_vars_finetune=config['y_vars'],
-                  spatial_idx_name='site_id',
-                  time_idx_name='date',
-                  train_start_date=config['train_start_date'],
-                  train_end_date=config['train_end_date'],
-                  val_start_date=config['val_start_date'],
-                  val_end_date=config['val_end_date'],
-                  test_start_date=config['test_start_date'],
-                  test_end_date=config['test_end_date'],
-                  out_file=output[0],
-                  trn_offset = config['trn_offset'],
-                  tst_val_offset = config['tst_val_offset'])
-
-
 
 # Finetune/train the model on observations
 rule train:
     input:
-        "{outdir}/nstates_{nstates}/rep_{rep}/prepped.npz"
+        "{outdir}/prepped.npz"
     output:
         directory("{outdir}/nstates_{nstates}/rep_{rep}/train_weights/"),
         #directory("{outdir}/best_val_weights/"),
@@ -82,7 +57,7 @@ rule make_predictions:
     input:
         "{outdir}/nstates_{nstates}/rep_{rep}/train_weights/",
         "../../../out/well_observed_trn_val_inputs.zarr",
-        "{outdir}/nstates_{nstates}/rep_{rep}/prepped.npz",
+        "{outdir}/prepped.npz",
     output:
         "{outdir}/nstates_{nstates}/rep_{rep}/preds.feather",
     run:
@@ -194,7 +169,7 @@ rule exp_metrics:
  
 rule plot_prepped_data:
      input:
-         "{outdir}/nstates_{nstates}/rep_{rep}/prepped.npz",
+         "{outdir}/prepped.npz",
      output:
          "{outdir}/nstates_{nstates}/rep_{rep}/{variable}_part_{partition}.png",
      run:

--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -2,6 +2,10 @@ import os
 import tensorflow as tf
 import numpy as np
 import pandas as pd
+import sys
+
+code_dir = "../river-dl"
+sys.path.append(code_dir)
 
 from river_dl.preproc_utils import asRunConfig
 from river_dl.preproc_utils import prep_all_data


### PR DESCRIPTION
This addition uses targets to do the following for each experiment specified:
1. produce the `prepped.npz` file so that it can be used to make the model predictions.
2. call snakemake to "touch" the "trained_weights" files so that they appear up to date
3. call snakemake to produce the final metrics file and all intermediate files including the predictions