### PR TITLE
[#116] combine io zarr files

### DIFF
--- a/2a_model.R
+++ b/2a_model.R
@@ -83,7 +83,7 @@ p2a_targets_list <- list(
       inputs_and_outputs <- inputs %>%
           left_join(do_and_metab, by=c("site_id", "date"))
       
-      subset_and_write_zarr(inputs_and_outputs, "2a_model/out/well_obs_io.zarr")
+      write_df_to_zarr(inputs_and_outputs, c("site_id", "date"), "2a_model/out/well_obs_io.zarr")
     },
     format="file"
   ),

--- a/2a_model.R
+++ b/2a_model.R
@@ -65,31 +65,25 @@ p2a_targets_list <- list(
 
   ## WRITE OUT PARTITION INPUT AND OUTPUT DATA ##
   # write trn met and seg attribute data to zarr
-  # note - I have to subset before passing to subset_and_write_zarr or else I
+  # note - I have to subset inputs before passing to subset_and_write_zarr or else I
   # get a memory error on the join
-  # write trn and val met and seg attribute data to zarr
-  # note - I have to subset before passing to subset_and_write_zarr or else I
-  # get a memory error on the join
+
+  # write trn and val input and output data to zarr
   tar_target(
-    p2a_well_obs_inputs_zarr,
-    { 
-      trn_input <- p2a_met_data_w_sites %>%
+    p2a_well_obs_data,
+    {
+      inputs <- p2a_met_data_w_sites %>%
         filter(site_id %in% p2a_trn_val_sites) %>%
         inner_join(p2a_seg_attr_w_sites, by = "site_id")
-      subset_and_write_zarr(trn_input, "2a_model/out/well_obs_inputs.zarr")
-    },
-    format="file"
-  ),
 
-
-  # write trn and val do and metab data to zarr
-  tar_target(
-    p2a_well_obs_targets_zarr,
-    {
       # need to join the metab data with the DO observations. 
       do_and_metab <- p2_daily_with_seg_ids %>%
           full_join(p2_metab_filtered, by=c("site_id", "date"))
-      subset_and_write_zarr(do_and_metab, "2a_model/out/well_obs_targets.zarr", p2a_trn_val_sites)
+
+      inputs_and_outputs <- inputs %>%
+          left_join(do_and_metab, by=c("site_id", "date"))
+      
+      subset_and_write_zarr(inputs_and_outputs, "2a_model/out/well_obs_io.zarr")
     },
     format="file"
   ),
@@ -119,8 +113,7 @@ p2a_targets_list <- list(
     p2a_metrics_files,
     {
     # we need these to make the prepped data file
-    p2a_well_obs_inputs_zarr
-    p2a_well_obs_targets_zarr
+    p2a_well_obs_data
     
     base_dir <- "2a_model/src/models"
     snakefile_path <- file.path(base_dir, p2a_model_ids$snakefile_dir, "Snakefile")

--- a/2a_model.R
+++ b/2a_model.R
@@ -64,8 +64,8 @@ p2a_targets_list <- list(
 
 
   ## WRITE OUT PARTITION INPUT AND OUTPUT DATA ##
-  # write trn met and seg attribute data to zarr
-  # note - I have to subset inputs before passing to subset_and_write_zarr or else I
+  # write met and seg attribute data for trn/val sites to zarr
+  # note - I have to subset inputs to only include the train/val sites before passing to subset_and_write_zarr or else I
   # get a memory error on the join
 
   # write trn and val input and output data to zarr
@@ -74,7 +74,7 @@ p2a_targets_list <- list(
     {
       inputs <- p2a_met_data_w_sites %>%
         filter(site_id %in% p2a_trn_val_sites) %>%
-        inner_join(p2a_seg_attr_w_sites, by = "site_id")
+        inner_join(p2a_seg_attr_w_sites, by = c("site_id", "seg_id_nat"))
 
       # need to join the metab data with the DO observations. 
       do_and_metab <- p2_daily_with_seg_ids %>%

--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -29,13 +29,12 @@ rule as_run_config:
 
 rule prep_io_data:
     input:
-        "../../../out/well_obs_inputs.zarr",
-        "../../../out/well_obs_targets.zarr",
+        "../../../out/well_obs_io.zarr",
     output:
         "{outdir}/prepped.npz"
     run:
         prep_all_data(x_data_file=input[0],
-                      y_data_file=input[1],
+                      y_data_file=input[0],
                       x_vars=config['x_vars'],
                       y_vars_finetune=config['y_vars'],
                       spatial_idx_name='site_id',
@@ -101,7 +100,7 @@ rule make_predictions:
     input:
         "{outdir}/prepped.npz",
         "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/train_weights/",
-        "../../../out/well_obs_inputs.zarr",
+        "../../../out/well_obs_io.zarr",
     output:
         "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/preds.feather",
     run:
@@ -175,7 +174,7 @@ def get_grp_arg(wildcards):
  
 rule combine_metrics:
      input:
-          "../../../out/well_obs_targets.zarr",
+          "../../../out/well_obs_io.zarr",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/trn_preds.feather",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/val_preds.feather",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/val_times_preds.feather"


### PR DESCRIPTION
This PR combines the "targets" and "inputs" zarr files into one.

I've tested this and made sure that using the new zarr file to create new prepped.npz files results in the same predictions and metrics files.

Closes #116; closes #118 