### PR TITLE
Delete NHM network adjacency matrix targets

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -182,21 +182,6 @@ p1_targets_list <- list(
     p1_seg_attr_data,
     arrow::read_feather("1_fetch/in/seg_attr_drb.feather")
   ),
-  
-  # Download DRB network adjacency matrix
-  tar_target(
-    p1_ntw_adj_matrix_csv,
-    download_sb_file(sb_id = "5f6a289982ce38aaa2449135",
-                     file_name = "distance_matrix_drb.csv",
-                     out_dir="1_fetch/out"),
-    format="file"
-  ),
-  
-  # Read in network adjacency matrix
-  tar_target(
-    p1_ntw_adj_matrix,
-    read_csv(p1_ntw_adj_matrix_csv,show_col_types = FALSE)
-  ),
 
   # Download and unzip metabolism estimates from https://www.sciencebase.gov/catalog/item/59eb9c0ae4b0026a55ffe389
   tar_target(


### PR DESCRIPTION
This PR deletes two targets related to the network adjacency matrix for the NHM fabric. We weren't using them anyway, and we don't expect to use them when we move to the NHD fabric, either. 

Closes #119 