### PR TITLE
Fetch nhdv2 static attributes

### DIFF
--- a/1_fetch/in/target_sciencebase_attributes.csv
+++ b/1_fetch/in/target_sciencebase_attributes.csv
@@ -1,0 +1,7 @@
+SB_dataset_name,attribute_name,attribute_description,attribute_units,SB_link
+BASIN_CHAR,BASIN_AREA,NHDPlusV2 flowline catchment area in square kilometers. -9999 denotes a flowline which has no catchment.,square kilometers,https://www.sciencebase.gov/catalog/item/57976a0ce4b021cadec97890
+BASIN_CHAR,BASIN_SLOPE,NHDPlusV2 flowline catchment's average slope in percent. -9999 denotes a flowline which has no catchment.,"percent (percent rise, also referred to as the percent slope)",https://www.sciencebase.gov/catalog/item/57976a0ce4b021cadec97890
+BASIN_CHAR,ELEV_MEAN,NHDPlusV2 flowline catchment's mean elevation in meters. -9999 denotes a flowline which has no catchment.,meters,https://www.sciencebase.gov/catalog/item/57976a0ce4b021cadec97890
+TWI,TWI,"Topographic wetness index, ln(a/S); where ln is the natural log, a is the upslope area per unit contour length and S is the slope at that point.  See http://ks.water.usgs.gov/Kansas/pubs/reports/wrir.99-4242.html and Wolock and McCabe, 1995 for more detail",ln(m),https://www.sciencebase.gov/catalog/item/56f97be4e4b0a6037df06b70
+IMPERVIOUS_COVER_2011,IMPV11,NLCD 2011 percent imperviousness ,percent,https://www.sciencebase.gov/catalog/item/57057a9be4b0d4e2b7571fbb
+RIP_TREE_CANOPY_2011,CNPY11_BUFF100,NLCD 2011 percent tree canopy in 100 meter riparian buffer ,percent,https://www.sciencebase.gov/catalog/item/570572e2e4b0d4e2b75718bc

--- a/1_fetch/src/fetch_nhdv2_attributes_from_sb.R
+++ b/1_fetch/src/fetch_nhdv2_attributes_from_sb.R
@@ -1,0 +1,116 @@
+#' Function to download segment and catchment attribute data from ScienceBase
+#' 
+#' @description This function downloads zipped files from ScienceBase. By calling 
+#' unzip_and_clip_sb_data(), this function also unzips the downloaded zipped files, 
+#' reads in the unzipped data table, and filters the CONUS-scale data to retain 
+#' the NHDPlusV2 COMID's of interest.
+#' 
+#' @details This function was pulled and modified from the inland salinity ml project:
+#' https://github.com/USGS-R/drb-inland-salinity-ml/blob/main/1_fetch/src/fetch_nhdv2_attributes_from_sb.R
+#' 
+#' @param vars_item rows from vars of interest table containing the sb item to download
+#' @param save_dir character string indicting the file path to save the unzipped data
+#' @param comids vector of COMIDs to retain from CONUS-scale datasets
+#' @param delete_local_copies logical, indicates whether to delete CONUS-scale 
+#' zipped/unzipped data copies from save_dir. Defaults to TRUE.
+#' 
+fetch_nhdv2_attributes_from_sb <- function(vars_item, save_dir, comids, 
+                                           delete_local_copies = TRUE){
+
+  message(sprintf("Downloading %s from ScienceBase...",
+                  unique(vars_item$SB_dataset_name)))
+  
+  # 1) Select items associated with ScienceBase ID to download
+  item_names <- sbtools::item_list_files(sb_id = unique(vars_item$sb_id)) %>%
+    filter(!grepl(".xml", fname)) %>%
+    pull(fname)
+  
+  # 2) Download data from ScienceBase
+  out_file <- download_sb_file(sb_id = unique(vars_item$sb_id),
+                               file_name = c(item_names),
+                               out_dir = save_dir)
+  
+  # 3) Select desired column names to be retained from original downloaded data
+  col_names <- vars_item %>%
+    split(., .$attribute_name) %>%
+    lapply(., function(x){
+      names <- c("COMID",
+        paste0("CAT_", x$attribute_name),
+        paste0("TOT_", x$attribute_name),
+        paste0("ACC_", x$attribute_name))
+    }) %>% 
+    do.call("c",.) %>%
+    unique()
+  
+  message(sprintf("Subsetting %s data to requested COMID's...",
+                  unique(vars_item$SB_dataset_name)))
+  
+  # 4) Unzip out_files, filter to COMIDs of interest, and return combined data frame
+  data_out <- lapply(out_file, unzip_and_clip_sb_data,
+                     col_names = col_names,
+                     comids = comids,
+                     save_dir = save_dir,
+                     delete_local_copies = delete_local_copies) %>%
+    Reduce(full_join,.) %>% 
+    suppressMessages() %>%
+    suppressWarnings()
+  
+  # 5) Save file
+  data_out_path <- paste0(save_dir,"/",unique(vars_item$SB_dataset_name),".csv")
+  write_csv(data_out,file = data_out_path)
+  
+  return(data_out_path)
+  
+}
+
+
+
+#' @description This function unzips zipped files downloaded from ScienceBase, 
+#' reads in the unzipped data table, and filters the CONUS-scale data to 
+#' retain the NHDPlusV2 COMID's of interest.
+#' 
+#' @param out_file character string indicating the file path of the zipped data
+#' @param col_names string vector containing the columns to return.
+#' @param comids vector of COMIDs to retain from CONUS-scale datasets
+#' @param save_dir character string indicting the file path to save the unzipped data
+#' @param delete_local_copies logical, indicates whether to delete CONUS-scale 
+#' zipped/unzipped data copies from save_dir. Defaults to TRUE.
+#' 
+unzip_and_clip_sb_data <- function(out_file, col_names, comids, save_dir, 
+                                   delete_local_copies = TRUE){
+
+  # Unzip downloaded file
+  unzip(zipfile = out_file, exdir = save_dir, overwrite = TRUE)
+  
+  # Parse name of unzipped file
+  file_name <- basename(out_file)
+  file_name_sans_ext <- tools::file_path_sans_ext(file_name)
+  
+  # Special handling 
+  # in the future consider replacing with fuzzy string matching to create file_name_new
+  if(file_name_sans_ext == "NHDV2_TMEAN7100_ANN_CONUS"){
+    file_name_sans_ext <- "TMEAN7100_ANN_CONUS"
+  }
+  
+  # this line finds the files within the desired directory that share file_name 
+  # but are not zip files
+  file_name_new <- grep(file_name_sans_ext,
+                        grep(list.files(save_dir), 
+                             pattern = "\\.zip$", value = TRUE, invert = TRUE),
+                        value=TRUE)
+  file_path <- paste0(save_dir,"/",file_name_new)
+  
+  # Read in data and filter to retain COMID's of interest
+  dat <- read_delim(file_path, show_col_types = FALSE) %>%
+    filter(COMID %in% comids) %>%
+    select(any_of(col_names))
+  
+  # Remove files
+  if(delete_local_copies == "TRUE"){
+    file.remove(out_file)
+    file.remove(file_path)
+  }
+  
+  return(dat)
+}
+

--- a/2_process.R
+++ b/2_process.R
@@ -180,7 +180,7 @@ p2_targets_list <- list(
  ),
  
  # Loop through the catchment attribute list and join individual data frames by 
- # COMID. Combine catchment attributes with NHDPlusv2 value-added attributes
+ # COMID. Combine catchment attributes with NHDPlusv2 value-added attributes (vaa)
  # and subset the data frame to the COMIDs included in the site list.
  tar_target(
    p2_seg_attr_data,

--- a/2_process/src/combine_nhdv2_attributes.R
+++ b/2_process/src/combine_nhdv2_attributes.R
@@ -1,0 +1,82 @@
+#' @description Function to read in and combine downloaded NHDv2 attribute data.
+#' Any values of -9999 are replaced with NA. 
+#' 
+#' @details This function was pulled and modified from the inland salinity ml project:
+#' https://github.com/USGS-R/drb-inland-salinity-ml/blob/main/2_process/src/process_nhdv2_attr.R
+#'
+#' @param file_path file path of downloaded NHDv2 attribute data table, including 
+#' file name and extension
+#' @param cols character string indicating which columns to retain from downloaded 
+#' attribute data; cols can take values "CAT", "ACC", or "TOT". Defaults to "CAT".
+#'
+process_attr_tables <- function(file_path, cols = c("CAT")){
+ 
+  # Read in downloaded data 
+  # only specify col_type for COMID since cols will differ for each downloaded file
+  dat <- read_csv(file_path, col_types = cols(COMID = "c"), show_col_types = FALSE)
+    
+  # Process downloaded data
+  dat_proc <- dat %>%
+    # retain desired columns ('CAT','ACC' or 'TOT')
+    select(c(COMID,starts_with(cols)))
+  
+  # Flag columns with undesired flag values (e.g. -9999)
+  flag_cols <- dat_proc %>%
+    select(where(function(x) -9999 %in% x)) %>% 
+    names()
+  
+  if(length(flag_cols) > 0){
+    message(sprintf("Replacing -9999 values with NA for the following attributes:\n\n%s\n", 
+                    paste(flag_cols, collapse = "\n")))
+  }
+  
+  # For columns with undesired flag values, replace -9999 with NA, else use existing value
+  dat_proc_out <- dat_proc %>%
+    mutate(across(all_of(flag_cols), ~case_when(. == -9999 ~ NA_real_, 
+                                                TRUE ~ as.numeric(.))))
+
+  return(dat_proc_out)
+  
+}
+
+
+
+#' @description Function to combine static attributes for selected NHDv2
+#' flowline reaches
+#' 
+#' @param nhd_lines sf data frame containing NHDPlusV2 flowlines
+#' @param cat_attr_list list object containing different catchment 
+#' attribute data frames
+#' @param vaa_cols character string or vector of strings containing which
+#' value-added attributes should be retained in nhd_lines
+#' @param sites_w_segs data frame containing observation locations with 
+#' their matched flowlines. Must contain column "COMID".
+#'
+combine_attr_data <- function(nhd_lines, cat_attr_list, vaa_cols, sites_w_segs){
+  
+  # Format vaa_cols so that entries are not case-sensitive
+  vaa_cols <- toupper(vaa_cols)
+  
+  # Combine list object containing catchment attributes into a single data frame
+  cat_attr_df <- cat_attr_list %>%
+    Reduce(full_join, .) %>%
+    # hide messages that data frames are being joined by 'COMID'
+    suppressMessages()
+  
+  # Combine catchment attributes with NHD value-added attributes for
+  # each flowline reach
+  attr_data <- nhd_lines %>%
+    rename_with(toupper) %>%
+    sf::st_drop_geometry() %>%
+    select(c("COMID", any_of(vaa_cols))) %>%
+    mutate(COMID = as.character(COMID)) %>%
+    left_join(y = cat_attr_df, by = "COMID")
+  
+  # Subset attribute data to the flowline reaches with observations
+  attr_data_sub <- attr_data %>%
+    filter(COMID %in% unique(sites_w_segs$COMID))
+    
+  return(attr_data_sub)
+  
+}
+


### PR DESCRIPTION
This PR downloads requested NHDv2 static attributes and combines them into a single summary table (`p2_seg_attr_data`) that is ready for further model prep in 2a_model.R _(for a separate PR once the gridMET drivers are ready)_.

To start, I've included a minimal set of attributes that are more or less analogous to the PRMS attributes (e.g. see Jeff's table [here](https://github.com/USGS-R/drb-do-ml/discussions/44)). These are segment/catchment slope, mean elevation, catchment area, and percent imperviousness. To represent maximum soil moisture (from PRMS), I included topographic wetness index, and to try to represent reach percent shade (from PRMS), I included the percent forest cover within a 100-m buffer of the stream from NLCD 2011. I plan to add to this list of attributes, but this set should be sufficient to test our workflow with the NHD fabric and can perhaps provide a point of comparison for the baseline LSTM using NHM vs the baseline LSTM using NHD.

Closes #129 