### PR TITLE
Update `p2_sites_w_segs` and med/well obs reaches to use nhdv2

### DIFF
--- a/2_process/src/calc_daily_light.R
+++ b/2_process/src/calc_daily_light.R
@@ -114,8 +114,7 @@ calc_seg_light_ratio <- function(segment, start_date, end_date){
   
   # Format columns
   daily_light_out <- daily_light %>%
-    mutate(subsegid = unique(segment$subsegid),
-           seg_id_nat = unique(segment$segidnat))
+    mutate(COMID = unique(segment$COMID))
   
   return(daily_light_out)
   


### PR DESCRIPTION
This PR updates `p2_sites_w_segs` and `p2_daily_with_seg_ids` to reference the NHDv2 network rather than the NHM network. In addition, this PR includes small edits to update `p2_well_observed_reaches`, `p2_med_observed_reaches`, and `p2_daily_max_light` to use NHDv2.

Here is a preview of `p2_daily_max_light` with these changes:

```
> tar_load(p2_daily_max_light)
> head(p2_daily_max_light)
# A tibble: 6 x 7
  date_localtime max_light sum_light day_length frac_light frac_daylength   COMID
  <date>             <dbl>     <dbl>      <dbl>      <dbl>          <dbl>   <int>
1 1979-09-30            0         0        NA     NaN             NA      4492036
2 1979-10-01         1690.    25104.       11.5     0.0673         0.0435 4492036
3 1979-10-02         1678.    24843.       11.5     0.0676         0.0435 4492036
4 1979-10-03         1667.    24583.       11.5     0.0678         0.0435 4492036
5 1979-10-04         1656.    24330.       10.5     0.0681         0.0476 4492036
6 1979-10-05         1644.    24089.       10.5     0.0683         0.0476 4492036
>
```

Closes #125 