### PR TITLE
Add new date variable to use when downloading NWIS data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -57,7 +57,7 @@ p1_targets_list <- list(
                         parameter = pcode_select,
                         stat_cd_select = stat_cd_select,
                         start_date = earliest_date,
-                        end_date = dummy_date),
+                        end_date = latest_date),
     pattern = map(p1_nwis_sites_daily)
   ),
 
@@ -70,7 +70,7 @@ p1_targets_list <- list(
                               parameterCd = c("00060", "00010", "00095"),
                               statCd = stat_cd_select,
                               startDate = earliest_date,
-                              endDate = dummy_date) %>%
+                              endDate = latest_date) %>%
     dataRetrieval::renameNWISColumns() %>%
     select(!starts_with("..2..")),
     pattern = map(p1_nwis_sites_daily)
@@ -87,12 +87,12 @@ p1_targets_list <- list(
   tar_target(
     p1_nwis_sites_inst,
     p1_nwis_sites %>%
-      # retain "uv" sites that contain data records after user-specified {earliest_date} and
-      # before user-specified {dummy_date}
+      # retain "uv" sites that contain data records after user-specified `earliest_date` and
+      # before user-specified `latest_date`
       filter(data_type_cd == "uv",
              !(site_no %in% omit_nwis_sites),
              end_date > earliest_date,
-             begin_date < dummy_date) %>%
+             begin_date < latest_date) %>%
       # for sites with multiple time series (ts_id), retain the most recent time series for site_info
       group_by(site_no) %>% arrange(desc(end_date)) %>% slice(1)
   ),
@@ -103,7 +103,7 @@ p1_targets_list <- list(
     get_inst_nwis_data(site_info =p1_nwis_sites_inst,
                        parameter = pcode_select,
                        start_date = earliest_date,
-                       end_date = dummy_date),
+                       end_date = latest_date),
     pattern = map(p1_nwis_sites_inst)
   ),
   
@@ -111,7 +111,7 @@ p1_targets_list <- list(
   tar_target(
     p1_nwis_sites_inst_multipleTS_csv,
     p1_nwis_sites %>%
-      # retain "uv" sites that contain data records after user-specified {earliest_date}
+      # retain "uv" sites that contain data records after user-specified `earliest_date`
       filter(data_type_cd == "uv",
              !(site_no %in% omit_nwis_sites),
              end_date > earliest_date) %>%

--- a/1_fetch/src/get_daily_nwis_data.R
+++ b/1_fetch/src/get_daily_nwis_data.R
@@ -1,25 +1,33 @@
-get_daily_nwis_data <- function(site_info,parameter,stat_cd_select,start_date = "",end_date = "") {
-  #' 
-  #' @description Function to download NWIS daily data
-  #'
-  #' @param site_info data frame containing site info for NWIS daily site, including the variable "site_no"
-  #' @param parameter a character vector containing the USGS parameter codes of interest
-  #' @param stat_cd_select a character vector containing the USGS stat codes to retain
-  #' @param start_date character string indicating the starting date for data retrieval (YYYY-MM-DD). 
-  #' Default value is "" to indicate retrieval for the earliest possible record.
-  #' @param end_date character string indicating the ending date for data retrieval (YYYY-MM-DD).
-  #' Default value is "" to indicate retrieval for the latest possible record. 
-  #'
-  #' @value A data frame containing daily values and data quality codes for each stat code (e.g. min/max/mean)
-  #' @examples 
-  #' get_daily_nwis_data(site_info = daily_sites,parameter="00300",stat_cd_select="00003")
-  #' get_daily_nwis_data(site_info = daily_sites,parameter="00095",stat_cd_select="00003",start_date = "2020-10-01",end_date="2021-09-30")
-  
+#' @description Function to download NWIS daily data
+#'
+#' @param site_info data frame containing site info for NWIS daily site, including the variable "site_no"
+#' @param parameter a character vector containing the USGS parameter codes of interest
+#' @param stat_cd_select a character vector containing the USGS stat codes to retain
+#' @param start_date character string indicating the starting date for data retrieval (YYYY-MM-DD). 
+#' Default value is "" to indicate retrieval for the earliest possible record.
+#' @param end_date character string indicating the ending date for data retrieval (YYYY-MM-DD).
+#' Default value is "" to indicate retrieval for the latest possible record. 
+#'
+#' @value A data frame containing daily values and data quality codes for each stat 
+#' code (e.g. min/max/mean)
+#' 
+#' @examples 
+#' get_daily_nwis_data(site_info = daily_sites, parameter="00300", 
+#'                     stat_cd_select="00003")
+#' get_daily_nwis_data(site_info = daily_sites, parameter="00095", 
+#'                     stat_cd_select="00003",
+#'                     start_date = "2020-10-01",end_date="2021-09-30")
+#'     
+get_daily_nwis_data <- function(site_info, parameter, stat_cd_select, 
+                                start_date = "", end_date = "") {
+                
   message(sprintf('Retrieving daily data for %s', site_info$site_no))
 
   # Download daily data
-  site_data <- dataRetrieval::readNWISdv(
-    siteNumbers = site_info$site_no,parameterCd=parameter,statCd=stat_cd_select,startDate = start_date,endDate = end_date) %>%
+  site_data <- dataRetrieval::readNWISdv(siteNumbers = site_info$site_no,
+                                         parameterCd = parameter,
+                                         statCd = stat_cd_select,
+                                         startDate = start_date, endDate = end_date) %>%
     dataRetrieval::renameNWISColumns(p00300="Value",p00095="Value")
   
   # Munge column names for some sites with different or unusually-named value columns
@@ -40,29 +48,32 @@ get_daily_nwis_data <- function(site_info,parameter,stat_cd_select,start_date = 
   # If no min/max value reported, create empty column(s):
   if(!('Value_Max' %in% names(site_data))){
     site_data <- site_data %>%
-      add_column(Value_Max = NA,
-                 Value_Max_cd = NA)
+      add_column(Value_Max = NA_real_,
+                 Value_Max_cd = NA_real_)
   }
   if(!('Value_Min' %in% names(site_data))){
     site_data <- site_data %>%
-      add_column(Value_Min = NA,
-                 Value_Min_cd = NA)
+      add_column(Value_Min = NA_real_,
+                 Value_Min_cd = NA_real_)
   }
   
   # Filter daily data
   site_data_out <- site_data %>%
            # omit rows with no data
     filter(!(is.na(Value) & is.na(Value_Max) & is.na(Value_Min)),
-           # omit rows where daily mean > daily max; daily min > daily max; or daily min > daily mean
+           # omit rows where daily mean > daily max,
+           # daily min > daily max, 
+           # or daily min > daily mean
           (is.na(Value)|is.na(Value_Max)|(!Value > Value_Max)),
           (is.na(Value_Min)|is.na(Value_Max)|(!Value_Min > Value_Max)),
           (is.na(Value)|is.na(Value_Min)|(!Value_Min > Value)),
           # omit rows with undesired data quality codes
-          !(grepl("eqp|mnt",Value_cd,ignore.case = TRUE)),
-          !(grepl("eqp|mnt",Value_Min_cd,ignore.case = TRUE)),
-          !(grepl("eqp|mnt",Value_Max_cd,ignore.case = TRUE))) %>%
-    mutate(Parameter=c("00095"="SpecCond","00300"="DO")[parameter]) %>%
-    select(agency_cd,site_no,Date,Parameter,Value,Value_cd,Value_Max,Value_Max_cd,Value_Min,Value_Min_cd)
+          !(grepl("eqp|mnt", Value_cd, ignore.case = TRUE)),
+          !(grepl("eqp|mnt", Value_Min_cd, ignore.case = TRUE)),
+          !(grepl("eqp|mnt", Value_Max_cd, ignore.case = TRUE))) %>%
+    mutate(Parameter = c("00095" = "SpecCond", "00300" = "DO")[parameter]) %>%
+    select(agency_cd, site_no, Date, Parameter, Value, Value_cd, 
+           Value_Max, Value_Max_cd, Value_Min, Value_Min_cd)
   
   return(site_data_out)
 }

--- a/1_fetch/src/get_inst_nwis_data.R
+++ b/1_fetch/src/get_inst_nwis_data.R
@@ -1,25 +1,32 @@
-get_inst_nwis_data <- function(site_info,parameter,start_date = "",end_date = "") {
-  #' 
-  #' @description Function to download NWIS instantaneous data
-  #'
-  #' @param site_info a data frame containing site info for NWIS instantaneous site. site_info must include the variable "site_no"
-  #' @param parameter a character vector containing the USGS parameter code of interest
-  #' @param start_date character string indicating the starting date for data retrieval (YYYY-MM-DD). 
-  #' Default value is "" to indicate retrieval for the earliest possible record.
-  #' @param end_date character string indicating the ending date for data retrieval (YYYY-MM-DD).
-  #' Default value is "" to indicate retrieval for the latest possible record.
-  #'
-  #' @value A data frame containing instantaneous values and data quality codes for the parameter of interest
-  #' @examples 
-  #' get_inst_nwis_data(site_info = data.frame(site_no="01484272"),parameter="00300")
-  #' get_inst_nwis_data(site_info = data.frame(site_no="01484272"),parameter="00095",start_date = "2020-10-01",end_date="2021-09-30")
+#' @description Function to download NWIS instantaneous data
+#'
+#' @param site_info a data frame containing site info for NWIS instantaneous site; 
+#' must include the variable "site_no"
+#' @param parameter a character vector containing the USGS parameter code of interest
+#' @param start_date character string indicating the starting date for data retrieval
+#' (YYYY-MM-DD). Default value is "" to indicate retrieval for the earliest possible record.
+#' @param end_date character string indicating the ending date for data retrieval 
+#' (YYYY-MM-DD). Default value is "" to indicate retrieval for the latest possible record.
+#'
+#' @value A data frame containing instantaneous values and data quality codes for 
+#' the parameter of interest
+#' 
+#' @examples 
+#' get_inst_nwis_data(site_info = data.frame(site_no="01484272"),parameter="00300")
+#' get_inst_nwis_data(site_info = data.frame(site_no="01484272"), parameter="00095", 
+#'                   start_date = "2020-10-01", end_date="2021-09-30")
+#'                   
+get_inst_nwis_data <- function(site_info, parameter, start_date = "", end_date = "") {
 
-  
   message(sprintf('Retrieving instantaneous data for %s', site_info$site_no))
 
-  # Download instantaneous data (use default time zone = "UTC" to avoid issues with daylight savings time)
-  site_data <- dataRetrieval::readNWISuv(
-    siteNumbers = site_info$site_no,parameterCd=parameter,startDate = start_date,endDate = end_date,tz = "UTC") %>%
+  # Download instantaneous data
+  # use default time zone = "UTC" to avoid issues with daylight savings time
+  site_data <- dataRetrieval::readNWISuv(siteNumbers = site_info$site_no, 
+                                         parameterCd=parameter,
+                                         startDate = start_date,
+                                         endDate = end_date,
+                                         tz = "UTC") %>%
     dataRetrieval::renameNWISColumns(p00300="Value",p00095="Value") 
   
   # Munge column names for some sites with different or unusually-named value columns
@@ -27,14 +34,16 @@ get_inst_nwis_data <- function(site_info,parameter,start_date = "",end_date = ""
     if(parameter == '00300') {
       site_data <- switch(
         site_info$site_no[1],
-        # 01467200: Potential relocation of sensors; multiple time series include ~6-month co-deployment that shows comparability of 
-        # time series ('Value_Inst' and 'ISM.Test.Bed.'). Select 'ISM.Test.Bed' when data are available, otherwise select 'Value_Inst' data:
+        # 01467200: Potential relocation of sensors; multiple time series include ~6-month 
+        # co-deployment that shows comparability of time series ('Value_Inst' and 'ISM.Test.Bed.'). 
+        # Select 'ISM.Test.Bed' when data are available, otherwise select 'Value_Inst' data:
         "01467200" = site_data %>%
           mutate(Value_Inst_merged = coalesce(`ISM.Test.Bed...ISM.Test.Bed..barge.._Value_Inst`,`Value_Inst`),
                  Value_Inst_cd_merged = coalesce(`ISM.Test.Bed...ISM.Test.Bed..barge.._Value_Inst_cd`,`Value_Inst_cd`)) %>%
           select(agency_cd,site_no,dateTime,Value_Inst_merged,Value_Inst_cd_merged,tz_cd) %>%
           rename("Value_Inst"="Value_Inst_merged","Value_Inst_cd"="Value_Inst_cd_merged"),
-        # 01482537: No site remarks given to indicate preferred time series, therefore, select longer ts (ts_id = 290960, "at.0.5.ft.depth_Value_Inst"):
+        # 01482537: No site remarks given to indicate preferred time series, therefore, select 
+        # longer ts (ts_id = 290960, "at.0.5.ft.depth_Value_Inst"):
         "01482537" = site_data %>%
           mutate(Value_Inst_merged = at.0.5.ft.depth_Value_Inst,
                  Value_Inst_cd_merged = at.0.5.ft.depth_Value_Inst_cd) %>%
@@ -44,23 +53,27 @@ get_inst_nwis_data <- function(site_info,parameter,start_date = "",end_date = ""
     if(parameter == "00095") {
       site_data <- switch(
         site_info$site_no[1],
-        # 01434498: Returned data contains time series from 'Side.Channel' and multiple piezometers. Select data that are representative of the main river channel:
+        # 01434498: Returned data contains time series from 'Side.Channel' and multiple piezometers. 
+        # Select data that are representative of the main river channel:
         "01434498" = site_data %>%
           select(agency_cd,site_no,dateTime,Value_Inst,Value_Inst_cd,tz_cd),
-        # 01435000: Returned data contains time series from 'Intake' and multiple piezometers. Select data that are representative of the main river channel:
+        # 01435000: Returned data contains time series from 'Intake' and multiple piezometers. 
+        # Select data that are representative of the main river channel:
         "01435000" = site_data %>%
           mutate(Value_Inst_merged = Channel.WQ_Value_Inst,
                  Value_Inst_cd_merged = Channel.WQ_Value_Inst_cd) %>%
           select(agency_cd,site_no,dateTime,Value_Inst_merged,Value_Inst_cd_merged,tz_cd) %>%
           rename("Value_Inst"="Value_Inst_merged","Value_Inst_cd"="Value_Inst_cd_merged"),
-        # 01467200: Potential sensor relocation; multiple time series include co-deployment period that shows comparability of time series ('Value_Inst', 'ISM.Test.Bed.'). 
-        # Select 'ISM.Test.Bed' when data are available, otherwise select 'Value_Inst' data:
+        # 01467200: Potential sensor relocation; multiple time series include co-deployment period 
+        # that shows comparability of time series ('Value_Inst', 'ISM.Test.Bed.'). Select 'ISM.Test.Bed' 
+        # when data are available, otherwise select 'Value_Inst' data:
         "01467200" = site_data %>%
           mutate(Value_Inst_merged = coalesce(`ISM.Test.Bed...ISM.Test.Bed..barge.._Value_Inst`,`Value_Inst`),
                  Value_Inst_cd_merged = coalesce(`ISM.Test.Bed...ISM.Test.Bed..barge.._Value_Inst_cd`,`Value_Inst_cd`)) %>%
           select(agency_cd,site_no,dateTime,Value_Inst_merged,Value_Inst_cd_merged,tz_cd) %>%
           rename("Value_Inst"="Value_Inst_merged","Value_Inst_cd"="Value_Inst_cd_merged"),
-        # 01482537: No site remarks given to indicate preferred time series, therefore, select longer ts (ts_id = 290960, "at.0.5.ft.depth_Value_Inst"):
+        # 01482537: No site remarks given to indicate preferred time series, therefore, select 
+        # longer ts (ts_id = 290960, "at.0.5.ft.depth_Value_Inst"):
         "01482537" = site_data %>%
           mutate(Value_Inst_merged = at.0.5.ft.depth_Value_Inst,
                  Value_Inst_cd_merged = at.0.5.ft.depth_Value_Inst_cd) %>%
@@ -72,10 +85,10 @@ get_inst_nwis_data <- function(site_info,parameter,start_date = "",end_date = ""
   # Return instantaneous data
   site_data_out <- site_data %>%
     # omit rows with undesired data quality codes
-    filter(!(grepl("eqp|mnt",Value_Inst_cd,ignore.case = TRUE))) %>%
-    mutate(Parameter=c("00095"="SpecCond","00300"="DO")[parameter]) %>%
+    filter(!(grepl("eqp|mnt", Value_Inst_cd, ignore.case = TRUE))) %>%
+    mutate(Parameter = c("00095" = "SpecCond", "00300" = "DO")[parameter]) %>%
     rename("time_zone" = "tz_cd") %>%
-    select(agency_cd,site_no,dateTime,Parameter,Value_Inst,Value_Inst_cd,time_zone)
+    select(agency_cd, site_no, dateTime, Parameter, Value_Inst, Value_Inst_cd, time_zone)
     
   return(site_data_out)
 }

--- a/2_process.R
+++ b/2_process.R
@@ -145,7 +145,7 @@ p2_targets_list <- list(
    { 
      calc_seg_light_ratio(p2_med_observed_reaches, 
                           start_date = earliest_date, 
-                          end_date = dummy_date)
+                          end_date = latest_date)
    },
    pattern = map(p2_med_observed_reaches)
  ),

--- a/_targets.R
+++ b/_targets.R
@@ -55,11 +55,12 @@ omit_nwis_sites <- c("01412350","01484272", "01477050", "01467200", "014670261",
 # Define USGS stat codes for continuous sites that only report daily statistics (https://help.waterdata.usgs.gov/stat_code) 
 stat_cd_select <- c("00001","00002","00003")
 
-# Define earliest startDate for NWIS data retrievals
+# Define earliest startDate and latest endDate for NWIS data retrievals
 earliest_date <- "1979-10-01"
+latest_date <- "2021-12-31"
 
 # Change dummy date to force re-build of NWIS DO sites and data download
-dummy_date <- "2021-12-19"
+dummy_date <- "2022-06-15"
 
 # test and validation sites
 val_sites <- c("01472104", "01473500", "01481500")


### PR DESCRIPTION
This PR adds a new variable to the _targets.R file. `latest_date` is used to indicate the latest desired end date when downloading date from NWIS. We'll still use `dummy_date` to update NWIS data downloads.

I've set `earliest_date` and `latest_date` as 10/1/1979 and 12/31/2021, respectively. I chose this `latest_date` because I was under the impression that data records are meant to be approved within 120 days, however, I noticed there's still some provisional data starting in August 2021. We may ultimately just opt to omit provisional data to avoid what we saw in #78 that considerable chunks of data had been removed from NWIS in between data pulls for several of our sites. 

This PR also includes a number of small formatting changes to follow a consistent code style in 1_fetch.R, but none of these should impact the outputs. A fresh data pull still produces 14 well-observed sites and 16 med-observed sites:

```
> tar_load(p2_well_observed_sites)
> tar_load(p2_med_observed_sites)
> length(p2_well_observed_sites)
[1] 14
> length(p2_med_observed_sites)
[1] 16
>
```


Closes #83 