### PR TITLE
Add NHDv2 gridmet targets to pipeline

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -300,6 +300,17 @@ p1_targets_list <- list(
     read_csv(p1_ref_gages_manual_csv, col_types = cols(.default = "c")) %>%
       mutate(id = str_replace(provider_id, "USGS-","")) %>%
       relocate(id, .after = provider_id)
+  ),
+  
+  # Read in meteorological data aggregated to NHDPlusV2 catchments for the 
+  # DRB (prepped in https://github.com/USGS-R/drb_gridmet_tools). Note that
+  # the DRB met data file must be stored in 1_fetch/in. If working outside
+  # of tallgrass/caldera, this file will need to be downloaded from the project
+  # S3 bucket and manually placed in 1_fetch/in.
+  tar_target(
+    p1_drb_nhd_gridmet,
+    "1_fetch/in/drb_climate_2022_06_14.nc",
+    format = "file"
   )
 
 )  

--- a/2_process.R
+++ b/2_process.R
@@ -198,6 +198,18 @@ p2_targets_list <- list(
                      cat_attr_list = p2_cat_attr_list,
                      vaa_cols = c("SLOPE"),
                      sites_w_segs = p2_sites_w_nhd_segs)
+ ),
+ 
+ # Subset the DRB meteorological data to only include the NHDPlusv2 catchments (COMID)
+ # that correspond with observation locations. 
+ tar_target(
+   p2_met_data_at_obs_sites,
+   {
+     reticulate::source_python("2_process/src/subset_nc_to_comid.py")
+     subset_nc_to_comids(p1_drb_nhd_gridmet, p2_med_observed_reaches$COMID) %>%
+       as_tibble() %>%
+       relocate(COMID, .before = "tmmx")
+   }
  )
 
 )

--- a/2_process.R
+++ b/2_process.R
@@ -208,7 +208,7 @@ p2_targets_list <- list(
      reticulate::source_python("2_process/src/subset_nc_to_comid.py")
      subset_nc_to_comids(p1_drb_nhd_gridmet, p2_med_observed_reaches$COMID) %>%
        as_tibble() %>%
-       relocate(COMID, .before = "tmmx")
+       relocate(c(COMID,time), .before = "tmmx")
    }
  )
 

--- a/2_process/src/subset_nc_to_comid.py
+++ b/2_process/src/subset_nc_to_comid.py
@@ -1,0 +1,36 @@
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+
+def ds_to_dataframe_faster(ds):
+    """
+    doing this to try to avoid the multi-index joins
+    """
+    series_list = []
+    for var in ds.data_vars:
+        if "lat" not in var and "lon" not in var:
+            df_var = ds[var].to_pandas().reset_index()
+            df_var_tidy = df_var.melt(id_vars='COMID', value_name=var)
+            series_list.append(df_var_tidy[var])
+    series_list.append(df_var_tidy['COMID'])
+    series_list.append(df_var_tidy['time'])
+    return pd.concat(series_list, axis=1)
+
+
+def subset_nc_to_comids(nc_file, comids):
+    comids = [int(c) for c in comids]
+
+    ds = xr.open_dataset(nc_file)
+
+    # filter out comids that are not in climate drivers (should only be 4781767)
+    comids = np.array(comids)
+    comids_in_climate = comids[np.isin(comids, ds.COMID.values)]
+    comids_not_in_climate = comids[~np.isin(comids, ds.COMID.values)]
+    print(comids_not_in_climate)
+
+    # make sure it's just the one that we are expecting
+    if len(comids_not_in_climate) > 0 :
+        assert list(comids_not_in_climate) == [4781767]
+    ds_comids = ds.sel(COMID=comids_in_climate)
+    return ds_to_dataframe_faster(ds_comids)


### PR DESCRIPTION
This PR adds two targets to the pipeline, including a file target that represents the NHD-aggregated gridmet driver data for the full DRB (`p1_drb_nhd_gridmet`) and another that subsets the gridmet data to those COMIDs where we have observations (`p2_met_data_at_obs_sites`). 

Here's a preview of the subset data:
```
> tar_load(p2_met_data_at_obs_sites)
> head(p2_met_data_at_obs_sites)
# A tibble: 6 x 10
    COMID time                 tmmx  tmmn    pr  srad    vs  rmax  rmin     sph
    <dbl> <dttm>              <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>   <dbl>
1 4492036 1978-12-31 19:00:00  61.9  47.8 0.481  35.8  9.57  86.1  58.5 0.00628
2 4495680 1978-12-31 19:00:00  59.3  48.8 0.632  35.6  7.70  82.8  66.0 0.00686
3 4495656 1978-12-31 19:00:00  58.4  48.0 0.634  35.7  7.63  84.2  66.9 0.00678
4 4784831 1978-12-31 19:00:00  59.9  48.9 0.610  35.5  7.77  82.2  65.5 0.00690
5 4782619 1978-12-31 19:00:00  58.1  48.3 0.625  35.5  7.61  84.8  67.5 0.00679
6 4782585 1978-12-31 19:00:00  57.3  46.7 0.610  36.0  7.57  88.8  69.0 0.00673
>
```

These targets were taken from #137 and modified a bit. The gridmet driver data are treated as a plain 'file' format target as opposed to a target that integrates with S3 and has `repository = aws`. This assumes that the DRB-scale gridmet data are available in 1_fetch/in.