### PR TITLE
Omit medium-observed targets

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -140,34 +140,15 @@ p2_targets_list <- list(
    }
  ),
  
- # make list of "moderately-observed" sites
- tar_target(
-   p2_med_observed_sites,
-   p2_sites_w_segs %>%
-     filter(count_days_nwis >= 100) %>%
-     pull(site_id)
- ),
- 
- # filter p1_reaches_sf to segments with "well-observed" sites
- tar_target(   
-   p2_med_observed_reaches,
-   {
-     med_obs_reach_ids <- p2_sites_w_segs %>%
-       filter(site_id %in% p2_med_observed_sites) %>% 
-       pull(COMID)
-     p1_nhd_reaches_sf %>% filter(COMID %in% med_obs_reach_ids)
-   }
- ),
- 
  # Estimate daily (normalized) max-light
  tar_target(
    p2_daily_max_light,
    { 
-     calc_seg_light_ratio(p2_med_observed_reaches, 
+     calc_seg_light_ratio(p2_well_observed_reaches, 
                           start_date = earliest_date, 
                           end_date = latest_date)
    },
-   pattern = map(p2_med_observed_reaches)
+   pattern = map(p2_well_observed_reaches)
  ),
 
  # Filter daily metabolism estimates based on model diagnostics
@@ -206,7 +187,7 @@ p2_targets_list <- list(
    p2_met_data_at_obs_sites,
    {
      reticulate::source_python("2_process/src/subset_nc_to_comid.py")
-     subset_nc_to_comids(p1_drb_nhd_gridmet, p2_med_observed_reaches$COMID) %>%
+     subset_nc_to_comids(p1_drb_nhd_gridmet, p2_well_observed_reaches$COMID) %>%
        as_tibble() %>%
        relocate(c(COMID,time), .before = "tmmx")
    }

--- a/2_process.R
+++ b/2_process.R
@@ -122,10 +122,11 @@ p2_targets_list <- list(
   ),
 
   # make list of "well-observed" sites
+  # for now only considering NWIS sites
   tar_target(
    p2_well_observed_sites,
    p2_sites_w_segs %>% 
-     filter(count_days_total >= min_obs_days) %>% 
+     filter(count_days_nwis >= min_obs_days) %>% 
      pull(site_id)
  ),
  

--- a/2_process.R
+++ b/2_process.R
@@ -125,7 +125,7 @@ p2_targets_list <- list(
   tar_target(
    p2_well_observed_sites,
    p2_sites_w_segs %>% 
-     filter(count_days_total > 300) %>% 
+     filter(count_days_total >= min_obs_days) %>% 
      pull(site_id)
  ),
  

--- a/2_process.R
+++ b/2_process.R
@@ -123,6 +123,8 @@ p2_targets_list <- list(
 
   # make list of "well-observed" sites
   # for now only considering NWIS sites
+  # only sites with observations above `min_obs_days` are kept
+  # where `min_obs_days` is defined in _targets.R
   tar_target(
    p2_well_observed_sites,
    p2_sites_w_segs %>% 

--- a/2a_model.R
+++ b/2a_model.R
@@ -108,6 +108,8 @@ p2a_targets_list <- list(
       inputs_and_outputs <- inputs %>%
           left_join(p2a_do_and_metab, by=c("site_id", "date"))
       
+      # note that if the name of well_obs_io.zarr is changed below, this change must
+      # also be made in 2a_model/src/Snakefile_base.smk (lines 32, 103, and 177).
       write_df_to_zarr(inputs_and_outputs, c("site_id", "date"), "2a_model/out/well_obs_io.zarr")
     },
     format="file"

--- a/2a_model.R
+++ b/2a_model.R
@@ -113,10 +113,8 @@ p2a_targets_list <- list(
     format="file"
   ),
   
- 
-  
   # gather model ids - add to this list when you want to reproduce
-  # outputs from a new model #add medium observed sites
+  # outputs from a new model 
   tar_target(
     p2a_model_ids,
     # paths are relative to 2a_model/src/models
@@ -144,10 +142,7 @@ p2a_targets_list <- list(
     {
     #we need these to make the prepped data file
     p2a_well_obs_data
-    
-    #add in the medium observed data
-    p2a_med_obs_data
-    
+
     base_dir <- "2a_model/src/models"
     snakefile_path <- file.path(base_dir, p2a_model_ids$snakefile_dir, "Snakefile")
     config_path <- file.path(base_dir, p2a_model_ids$config_path)
@@ -170,27 +165,6 @@ p2a_targets_list <- list(
     },
     format="file",
     pattern = map(p2a_model_ids)
-  ),
-  
-  
-  ## CREATE EQUIVALENT TARGETS FOR "MODERATELY-OBSERVED SITES" ##
-  # write input/output data to zarr for the medium-observed sites
-  tar_target(
-    p2a_med_obs_data,
-    {
-      inputs_med_obs <- p2a_met_data_w_sites %>%
-        # include all med-obs sites not in testing sites
-        filter(site_id %in% p2_med_observed_sites, 
-               !site_id %in% tst_sites) %>%
-        inner_join(p2a_seg_attr_w_sites, by = c("site_id","COMID"))
-      
-      inputs_and_outputs_med_obs <- inputs_med_obs %>%
-        left_join(p2a_do_and_metab, by = c("site_id", "date"))
-      
-      write_df_to_zarr(inputs_and_outputs_med_obs, c("site_id","date"),
-                       "2a_model/out/med_obs_io.zarr")
-    },
-    format = "file"
   )
   
 )

--- a/2a_model.R
+++ b/2a_model.R
@@ -109,7 +109,8 @@ p2a_targets_list <- list(
           left_join(p2a_do_and_metab, by=c("site_id", "date"))
       
       # note that if the name of well_obs_io.zarr is changed below, this change must
-      # also be made in 2a_model/src/Snakefile_base.smk (lines 32, 103, and 177).
+      # also be made in 2a_model/src/Snakefile_base.smk (lines 32, 103, and 177) and
+      # in 2a_model/src/visualize_models.smk (line 6). 
       write_df_to_zarr(inputs_and_outputs, c("site_id", "date"), "2a_model/out/well_obs_io.zarr")
     },
     format="file"

--- a/2a_model/src/models/0_baseline_LSTM/config.yml
+++ b/2a_model/src/models/0_baseline_LSTM/config.yml
@@ -1,7 +1,5 @@
 exp_name: "0_baseline_LSTM"
 
-site_set: "med_obs"
-
 x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
 
 y_vars: ['do_min', 'do_mean', 'do_max']

--- a/2a_model/src/models/1_metab_multitask/1a_multitask_do_gpp_er.yml
+++ b/2a_model/src/models/1_metab_multitask/1a_multitask_do_gpp_er.yml
@@ -1,7 +1,5 @@
 exp_name: "1a_multitask_do_gpp_er"
 
-site_set: "med_obs"
-
 x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
 
 y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']

--- a/2a_model/src/models/1_metab_multitask/2b_multitask_do_gpp.yml
+++ b/2a_model/src/models/1_metab_multitask/2b_multitask_do_gpp.yml
@@ -1,7 +1,5 @@
 exp_name: "1b_multitask_do_gpp"
 
-site_set: "med_obs"
-
 x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
 
 y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']

--- a/2a_model/src/models/1_metab_multitask/config.yml
+++ b/2a_model/src/models/1_metab_multitask/config.yml
@@ -1,7 +1,5 @@
 exp_name: "1_metab_multitask"
 
-site_set: "med_obs"
-
 x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
 
 y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']

--- a/2a_model/src/models/2_multitask_dense/config.yml
+++ b/2a_model/src/models/2_multitask_dense/config.yml
@@ -1,7 +1,5 @@
 exp_name: "2_multitask_dense"
 
-site_set: "med_obs"
-
 x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
 
 y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']

--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -17,7 +17,6 @@ from river_dl import loss_functions as lf
 
 out_dir = os.path.join(config['out_dir'], config['exp_name'])
 loss_function = lf.multitask_rmse(config['lambdas'])
-site_set = config['site_set']
 
 include: "visualize_models.smk"
 
@@ -30,7 +29,7 @@ rule as_run_config:
 
 rule prep_io_data:
     input:
-        f"../../../out/{site_set}_io.zarr",
+        f"../../../out/well_obs_io.zarr",
     output:
         "{outdir}/prepped.npz"
     run:
@@ -101,7 +100,7 @@ rule make_predictions:
     input:
         "{outdir}/prepped.npz",
         "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/train_weights/",
-        f"../../../out/{site_set}_io.zarr",
+        f"../../../out/well_obs_io.zarr",
     output:
         "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/preds.feather",
     run:
@@ -175,7 +174,7 @@ def get_grp_arg(wildcards):
  
 rule combine_metrics:
      input:
-          f"../../../out/{site_set}_io.zarr",
+          f"../../../out/well_obs_io.zarr",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/trn_preds.feather",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/val_preds.feather",
           "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/val_times_preds.feather"

--- a/2a_model/src/models/visualize_models.smk
+++ b/2a_model/src/models/visualize_models.smk
@@ -1,11 +1,9 @@
 from model_plots import plot_obs_preds
 
-site_set = config['site_set']
-
 rule make_obs_preds_plots:
     input:
         pred_file="{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/preds.feather",
-        obs_file=f"../../../out/{site_set}_io.zarr",
+        obs_file=f"../../../out/well_obs_io.zarr",
     output:
         "{outdir}/nstates_{nstates}/nep_{epochs}/rep_{rep}/plots/ts_{site_id}_{year}.png"
     run:

--- a/_targets.R
+++ b/_targets.R
@@ -67,6 +67,10 @@ stat_cd_select <- c("00001","00002","00003")
 earliest_date <- "1979-10-01"
 latest_date <- "2021-12-31"
 
+# What is the minimum number of unique observation-days a site should have
+# to be considered "well-observed" and therefore, included in the model?
+min_obs_days <- 300
+
 # Change dummy date to force re-build of NWIS DO sites and data download
 dummy_date <- "2022-06-15"
 

--- a/_targets.R
+++ b/_targets.R
@@ -69,7 +69,9 @@ latest_date <- "2021-12-31"
 
 # What is the minimum number of unique observation-days a site should have
 # to be considered "well-observed" and therefore, included in the model?
-min_obs_days <- 300
+# Note that if min_obs_days is changed from 100 below, you may want to 
+# reconsider the train/test model splits. 
+min_obs_days <- 100
 
 # Change dummy date to force re-build of NWIS DO sites and data download
 dummy_date <- "2022-06-15"


### PR DESCRIPTION
This PR makes the following code changes to simplify the pipeline:

- add an object called `min_obs_days` to `_targets.R`. `min_obs_days` is used to define the minimum number of observation-days a site should have before it's considered "well-observed" and used in the model. `min_obs_days` replaces `"300"` in `p2_well_observed_sites` and therefore serves as an input that can be modified by the user. 
- define `min_obs_days <- 100` so that our "well-observed" site targets now reflect our decision to use what we were previously calling "medium-observed" sites (see #122 for more detail)
- omit targets that refer to "med-observed" sites in `2_process.R` and `2a_model.R`

To maintain consistency with our previous model runs using the medium-obs sites, `p2_well_observed_sites` only looks for NWIS daily or instantaneous sites with at least 100 days, although some of our discrete sites also contain data from 100+ days.

Closes #148 