### PR TITLE
Download NHDPlusv2 flowlines by COMID

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -135,10 +135,28 @@ p1_targets_list <- list(
     format = "file"
   ),
   
-  # Fetch NHDv2 flowline reaches for the area of interest
+  # Fetch NHM-NHDv2 crosswalk table from USGS-R/drb-network-prep.
+  tar_target(
+    p1_GFv1_NHDv2_xwalk,
+    read_csv(GFv1_NHDv2_xwalk_url, col_types = cols(.default = "c"))
+  ),
+  
+  # Reshape crosswalk table to return all NHDPlusv2 COMIDs in the DRB.
+  tar_target(
+    p1_drb_comids_all_tribs,
+    p1_GFv1_NHDv2_xwalk %>%
+      select(PRMS_segid, segidnat, comid_cat) %>%
+      tidyr::separate_rows(comid_cat, sep = ";") %>%
+      rename(COMID = comid_cat)
+  ),
+  
+  # Fetch NHDv2 flowline reaches for the full DRB, and then subset data frame
+  # to only include flowlines within the lower DRB. 
   tar_target(
     p1_nhd_reaches_sf,
-    download_nhdplus_flowlines(huc8 = drb_huc8s)
+    download_nhdplus_flowlines(comid = p1_drb_comids_all_tribs$COMID) %>%
+      mutate(huc8 = stringr::str_sub(REACHCODE, start = 1, end = 8)) %>%
+      filter(huc8 %in% drb_huc8s)
   ),
   
   # Read in csv file containing the segment/catchment attributes that we want

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -134,27 +134,26 @@ p1_targets_list <- list(
     command = target_summary_stats(p1_inst_data,"Value_Inst","1_fetch/log/inst_timeseries_summary.csv"),
     format = "file"
   ),
-  
-  # Fetch NHM-NHDv2 crosswalk table from USGS-R/drb-network-prep.
+
+  # Create sf polygon that represents the area of interest (AOI) based 
+  # on the HUC8 identifiers defined in _targets.R
   tar_target(
-    p1_GFv1_NHDv2_xwalk,
-    read_csv(GFv1_NHDv2_xwalk_url, col_types = cols(.default = "c"))
-  ),
-  
-  # Reshape crosswalk table to return all NHDPlusv2 COMIDs in the DRB.
-  tar_target(
-    p1_drb_comids_all_tribs,
-    p1_GFv1_NHDv2_xwalk %>%
-      select(PRMS_segid, segidnat, comid_cat) %>%
-      tidyr::separate_rows(comid_cat, sep = ";") %>%
-      rename(COMID = comid_cat)
+    p1_lower_drb_aoi,
+    drb_huc8s %>%
+      lapply(.,function(x){
+        # download huc8 basin polygon
+        nhdplusTools::get_huc8(id = x)
+      }) %>%
+      bind_rows() %>%
+      sf::st_bbox() %>%
+      sf::st_as_sfc()
   ),
   
   # Fetch NHDv2 flowline reaches for the full DRB, and then subset data frame
   # to only include flowlines within the lower DRB. 
   tar_target(
     p1_nhd_reaches_sf,
-    download_nhdplus_flowlines(comid = p1_drb_comids_all_tribs$COMID) %>%
+    download_nhdplus_flowlines(aoi = p1_lower_drb_aoi) %>%
       mutate(huc8 = stringr::str_sub(REACHCODE, start = 1, end = 8)) %>%
       filter(huc8 %in% drb_huc8s)
   ),

--- a/1_fetch/src/download_nhdplus_flowlines.R
+++ b/1_fetch/src/download_nhdplus_flowlines.R
@@ -39,7 +39,9 @@ download_nhdplus_flowlines <- function(comid = NULL, huc8 = NULL){
         flines_sub_out <- flines_sub %>%
           mutate(across(c(lakefract, surfarea, rareahload,hwnodesqkm), as.character))
         }) %>%
-      bind_rows()
+      bind_rows() %>%
+      # Reformat variable names to uppercase
+      rename_with(.,toupper,id:enabled)
     
   } else {
     

--- a/1_fetch/src/download_nhdplus_flowlines.R
+++ b/1_fetch/src/download_nhdplus_flowlines.R
@@ -1,24 +1,27 @@
-#' Function to download NHDPlus flowlines given a set of COMIDs or HUC8 codes
+#' Function to download NHDPlus flowlines given a set of COMIDs, HUC8 codes, or AOI
 #' 
 #' @param comid character string or vector of character strings containing
 #' the common identifier (COMID) of the desired flowline(s). Defaults to NULL.
 #' @param huc8 character string or vector of character strings containing
 #' the HUC8 sub-basin(s) over which to fetch flowlines. Defaults to NULL.
+#' @param aoi sf or sfc polygon object that represents the area of interest
+#' over which to fetch flowlines. Defaults to NULL.
 #' 
-#' @details One of `comid` or `huc8` should be NULL. In other words, the 
-#' user should choose to download flowlines by COMID or HUC8.
+#' @details One of `comid`, `huc8`, or `aoi` should be NULL. In other words, the 
+#' user should choose to download flowlines by COMID, HUC8 identifier, OR AOI.
 #' 
 #' 
-download_nhdplus_flowlines <- function(comid = NULL, huc8 = NULL){
+download_nhdplus_flowlines <- function(comid = NULL, huc8 = NULL, aoi = NULL){
   
-  if(!is.null(comid) & !is.null(huc8)){
-    stop("download_nhdplus_flowlines accepts arguments `comid` or 
-         `huc8` but not both.")
+  check_args <- c(is.null(comid), is.null(huc8), is.null(aoi))
+    
+  if(length(check_args[check_args == TRUE]) < 2){
+    stop("download_nhdplus_flowlines accepts arguments `comid` OR 
+         `huc8` OR `aoi`, but only one of them should not be NULL.")
   }
   
+  # Download flowlines by comid
   if(!is.null(comid)){
-    
-    # Download flowlines by comid
   
     # Chunk desired COMIDs into groups, where each group has no more than
     # 50 COMID's to avoid timeout errors when downloading nhdplus subsets
@@ -39,28 +42,34 @@ download_nhdplus_flowlines <- function(comid = NULL, huc8 = NULL){
         flines_sub_out <- flines_sub %>%
           mutate(across(c(lakefract, surfarea, rareahload,hwnodesqkm), as.character))
         }) %>%
-      bind_rows() %>%
-      # Reformat variable names to uppercase
-      rename_with(.,toupper,id:enabled)
-    
-  } else {
-    
-    # Download flowlines by area of interest/HUC8
+      bind_rows() 
+  } 
+  
+  # Download flowlines by HUC8
+  if(!is.null(huc8)){
     flines_by_huc <- huc8 %>%
       lapply(.,function(x){
         # create spatial object of huc8 basin
-        huc8_basin <- suppressMessages(nhdplusTools::get_huc8(id=x))
+        huc8_basin <- nhdplusTools::get_huc8(id=x)
         # download NHDPlusV2 flowlines within each huc8 bbox
-        huc8_flines <- suppressMessages(nhdplusTools::get_nhdplus(AOI = huc8_basin,
-                                                                  realization="flowline"))
+        huc8_flines <- nhdplusTools::get_nhdplus(AOI = huc8_basin, 
+                                                 realization = "flowline")
       })
     
     # Bind HUC8 flowlines together 
     flowlines <- flines_by_huc %>%
-      bind_rows() %>%
-      # Reformat variable names to uppercase
-      rename_with(.,toupper,id:enabled)
+      bind_rows()
   }
+  
+  # Download flowlines by area of interest 
+  if(!is.null(aoi)){
+    flowlines <- nhdplusTools::get_nhdplus(AOI = aoi, 
+                                           realization = "flowline")
+  }
+  
+  # Reformat variable names to uppercase
+  flowlines <- flowlines %>%
+    rename_with(.,toupper,id:enabled)
   
   return(flowlines)
   

--- a/_targets.R
+++ b/_targets.R
@@ -51,6 +51,14 @@ pcode_select <- c("00300")
 # Lower Delaware: 020402 accounting code 
 drb_huc8s <- c("02040201","02040202","02040203","02040204","02040205","02040206","02040207")
 
+# Define the url for the NHGFv1-NHDv2 crosswalk table. Note that there are
+# multiple versions of the crosswalk table in USGS-R/drb-network-prep. Read
+# in the NHM-NHDv2 crosswalk file that contains all NHDPlusv2 COMIDs in the
+# DRB (including divergent reaches and reaches without NHDv2 catchments).
+GFv1_NHDv2_xwalk_url <- paste0("https://raw.githubusercontent.com/USGS-R/drb-network-prep/",
+                               "3637931f5a17469a4234eaed3d20ed44ba45958d",
+                               "/2_process/out/GFv1_NHDv2_xwalk.csv")
+
 # Define USGS site types for which to download NWIS data 
 # (https://maps.waterdata.usgs.gov/mapper/help/sitetype.html)
 site_tp_select <- c("ST","ST-CA","SP") 

--- a/_targets.R
+++ b/_targets.R
@@ -51,14 +51,6 @@ pcode_select <- c("00300")
 # Lower Delaware: 020402 accounting code 
 drb_huc8s <- c("02040201","02040202","02040203","02040204","02040205","02040206","02040207")
 
-# Define the url for the NHGFv1-NHDv2 crosswalk table. Note that there are
-# multiple versions of the crosswalk table in USGS-R/drb-network-prep. Read
-# in the NHM-NHDv2 crosswalk file that contains all NHDPlusv2 COMIDs in the
-# DRB (including divergent reaches and reaches without NHDv2 catchments).
-GFv1_NHDv2_xwalk_url <- paste0("https://raw.githubusercontent.com/USGS-R/drb-network-prep/",
-                               "3637931f5a17469a4234eaed3d20ed44ba45958d",
-                               "/2_process/out/GFv1_NHDv2_xwalk.csv")
-
 # Define USGS site types for which to download NWIS data 
 # (https://maps.waterdata.usgs.gov/mapper/help/sitetype.html)
 site_tp_select <- c("ST","ST-CA","SP") 


### PR DESCRIPTION
This PR includes code changes to download the NHDPlusv2 flowlines by ~~COMID~~ AOI rather than by the HUC8 identifier. Downloading by HUC8 using `nhdplusTools::get_nhdplus()` results in some missing flowlines along the mainstem that made our site map look kind of wonky. To download flowlines by ~~COMID~~ AOI, I added ~~two~~ one new target to represent the lower DRB and our area of interest, ~~fetch and format the NHM-NHDv2 crosswalk table from USGS-R/drb-network-prep. The crosswalk table contains all of the COMIDs in the Delaware River Basin, and so~~ this PR modifies the target `p1_nhd_reaches_sf` to use ~~those COMIDs~~ the AOI when downloading the flowlines.

Note that the changes here should not impact the input datasets for modeling or the site splits (e.g. `p2a_site_splits`).

Closes #150 