### PR TITLE
Build model config files within targets pipeline

### DIFF
--- a/2a_model.R
+++ b/2a_model.R
@@ -87,13 +87,22 @@ p2a_targets_list <- list(
       sf::st_as_sf(., coords = c("lon","lat"), crs = unique(.$epsg))
   ),
   
-  ## WRITE MODEL CONFIG FILES ##
+  ## WRITE MODEL CONFIGURATION FILES ##
   # Write baseline model config file using inputs and parameters defined 
   # in the _targets.R file.
   tar_target(
     p2a_config_base_yml,
     write_config_file(cfg_options = base_config_options,
                       fileout = "2a_model/src/models/config_base.yml"),
+    format = "file"
+  ),
+  
+  # Write model config file for 0_baseline_LSTM
+  tar_target(
+    p2a_config_baseline_LSTM_yml,
+    write_config_file(cfg_options = model_config_options,
+                      fileout = "2a_model/src/models/0_baseline_LSTM/config.yml",
+                      exp_name = "0_baseline_LSTM"),
     format = "file"
   ),
   

--- a/2a_model.R
+++ b/2a_model.R
@@ -87,29 +87,13 @@ p2a_targets_list <- list(
       sf::st_as_sf(., coords = c("lon","lat"), crs = unique(.$epsg))
   ),
   
-  # Write baseline model config file
+  ## WRITE MODEL CONFIG FILES ##
+  # Write baseline model config file using inputs and parameters defined 
+  # in the _targets.R file.
   tar_target(
     p2a_config_base_yml,
-    write_base_config_file(fileout = "2a_model/src/models/config_base_test.yml", 
-                           model_save_dir = "../../../out/models", 
-                           seed = seed, 
-                           n_reps = n_model_reps, 
-                           trn_offset = trn_offset, 
-                           tst_val_offset = tst_val_offset, 
-                           early_stopping = early_stopping, 
-                           epochs = epochs, 
-                           hidden_size = hidden_size, 
-                           dropout = dropout,
-                           recurrent_dropout = recurrent_dropout, 
-                           finetune_learning_rate = finetune_learning_rate,
-                           val_sites = val_sites, 
-                           test_sites = tst_sites,
-                           train_start_date = train_start_date, 
-                           train_end_date = train_end_date, 
-                           val_start_date = val_start_date, 
-                           val_end_date = val_end_date,
-                           test_start_date = test_start_date, 
-                           test_end_date = test_end_date),
+    write_config_file(cfg_options = base_config_options,
+                      fileout = "2a_model/src/models/config_base.yml"),
     format = "file"
   ),
   

--- a/2a_model.R
+++ b/2a_model.R
@@ -88,8 +88,7 @@ p2a_targets_list <- list(
   ),
   
   ## WRITE MODEL CONFIGURATION FILES ##
-  # Write baseline model config file using inputs and parameters defined 
-  # in the _targets.R file.
+  # Write base config file using inputs and parameters defined in _targets.R
   tar_target(
     p2a_config_base_yml,
     write_config_file(cfg_options = base_config_options,
@@ -103,6 +102,33 @@ p2a_targets_list <- list(
     write_config_file(cfg_options = model_config_options,
                       fileout = "2a_model/src/models/0_baseline_LSTM/config.yml",
                       exp_name = "0_baseline_LSTM"),
+    format = "file"
+  ),
+  
+  # Write model config file for 1_metab_multitask
+  tar_target(
+    p2a_config_metab_multitask_yml,
+    write_config_file(cfg_options = metab_multitask_config_options,
+                      fileout = "2a_model/src/models/1_metab_multitask/config.yml",
+                      exp_name = "1_metab_multitask"),
+    format = "file"
+  ),
+  
+  # Write model config file for 1a_multitask_do_gpp_er
+  tar_target(
+    p2a_config_1a_metab_multitask_yml,
+    write_config_file(cfg_options = metab_1a_multitask_config_options,
+                      fileout = "2a_model/src/models/1_metab_multitask/1a_multitask_do_gpp_er.yml",
+                      exp_name = "1a_multitask_do_gpp_er"),
+    format = "file"
+  ),
+  
+  # Write model config file for 1b_multitask_do_gpp
+  tar_target(
+    p2a_config_1b_metab_multitask_yml,
+    write_config_file(cfg_options = metab_1b_multitask_config_options,
+                      fileout = "2a_model/src/models/1_metab_multitask/1b_multitask_do_gpp.yml",
+                      exp_name = "1b_multitask_do_gpp"),
     format = "file"
   ),
   

--- a/2a_model.R
+++ b/2a_model.R
@@ -1,4 +1,5 @@
 source("2a_model/src/model_ready_data_utils.R")
+source("2a_model/src/write_model_config_files.R")
 
 p2a_targets_list <- list(
 
@@ -85,7 +86,32 @@ p2a_targets_list <- list(
                          datum == "OTHER" ~ 4326)) %>%
       sf::st_as_sf(., coords = c("lon","lat"), crs = unique(.$epsg))
   ),
-
+  
+  # Write baseline model config file
+  tar_target(
+    p2a_config_base_yml,
+    write_base_config_file(fileout = "2a_model/src/models/config_base_test.yml", 
+                           model_save_dir = "../../../out/models", 
+                           seed = seed, 
+                           n_reps = n_model_reps, 
+                           trn_offset = trn_offset, 
+                           tst_val_offset = tst_val_offset, 
+                           early_stopping = early_stopping, 
+                           epochs = epochs, 
+                           hidden_size = hidden_size, 
+                           dropout = dropout,
+                           recurrent_dropout = recurrent_dropout, 
+                           finetune_learning_rate = finetune_learning_rate,
+                           val_sites = val_sites, 
+                           test_sites = tst_sites,
+                           train_start_date = train_start_date, 
+                           train_end_date = train_end_date, 
+                           val_start_date = val_start_date, 
+                           val_end_date = val_end_date,
+                           test_start_date = test_start_date, 
+                           test_end_date = test_end_date),
+    format = "file"
+  ),
   
   ## WRITE OUT PARTITION INPUT AND OUTPUT DATA ##
   # write met and seg attribute data for trn/val sites to zarr

--- a/2a_model.R
+++ b/2a_model.R
@@ -175,21 +175,23 @@ p2a_targets_list <- list(
   tar_target(
     p2a_model_ids,
     # paths are relative to 2a_model/src/models
-      list(list(model_id = "0_baseline_LSTM",
-                  snakefile_dir = "0_baseline_LSTM",
-                  config_path = "0_baseline_LSTM/config.yml"),
-         #the 1_ models use the same model and therefore
-         #the same Snakefile as the 0_baseline_LSTM run
-         list(model_id = "1_metab_multitask",
-              snakefile_dir = "0_baseline_LSTM",
-              config_path = "1_metab_multitask/config.yml"),
-         list(model_id = "1a_multitask_do_gpp_er",
-              snakefile_dir = "0_baseline_LSTM",
-              config_path = "1_metab_multitask/1a_multitask_do_gpp_er.yml"),
-         list(model_id = "2_multitask_dense",
-              snakefile_dir = "2_multitask_dense",
-              config_path = "2_multitask_dense/config.yml")),
-          iteration = "list"
+      list(
+        list(model_id = "0_baseline_LSTM",
+             snakefile_dir = "0_baseline_LSTM",
+             config_path = stringr::str_remove(p2a_config_baseline_LSTM_yml, "2a_model/src/models/")),
+        # the 1_ models use the same model and therefore the same Snakefile
+        # as the 0_baseline_LSTM run
+        list(model_id = "1_metab_multitask",
+             snakefile_dir = "0_baseline_LSTM",
+             config_path = stringr::str_remove(p2a_config_metab_multitask_yml, "2a_model/src/models/")),
+        list(model_id = "1a_multitask_do_gpp_er",
+             snakefile_dir = "0_baseline_LSTM",
+             config_path = stringr::str_remove(p2a_config_1a_metab_multitask_yml, "2a_model/src/models/")),
+        list(model_id = "2_multitask_dense",
+             snakefile_dir = "2_multitask_dense",
+             config_path = stringr::str_remove(p2a_config_multitask_dense_yml, "2a_model/src/models/"))
+        ),
+    iteration = "list"
   ),
 
   # produce the final metrics files (and all intermediate files including predictions)

--- a/2a_model.R
+++ b/2a_model.R
@@ -132,6 +132,15 @@ p2a_targets_list <- list(
     format = "file"
   ),
   
+  # Write model config file for 2_multitask_dense
+  tar_target(
+    p2a_config_multitask_dense_yml,
+    write_config_file(cfg_options = multitask_dense_config_options,
+                      fileout = "2a_model/src/models/2_multitask_dense/config.yml",
+                      exp_name = "2_multitask_dense"),
+    format = "file"
+  ),
+  
   ## WRITE OUT PARTITION INPUT AND OUTPUT DATA ##
   # write met and seg attribute data for trn/val sites to zarr
   # note - I have to subset inputs to only include the train/val sites before 

--- a/2a_model/src/models/0_baseline_LSTM/config.yml
+++ b/2a_model/src/models/0_baseline_LSTM/config.yml
@@ -1,3 +1,4 @@
+exp_name: "0_baseline_LSTM"
 x_vars:
   - "pr"
   - "SLOPE"
@@ -18,5 +19,4 @@ lambdas:
   - 1
   - 1
   - 1
-exp_name: "0_baseline_LSTM"
  

--- a/2a_model/src/models/0_baseline_LSTM/config.yml
+++ b/2a_model/src/models/0_baseline_LSTM/config.yml
@@ -1,16 +1,4 @@
 exp_name: "0_baseline_LSTM"
-x_vars:
-  - "pr"
-  - "SLOPE"
-  - "tmmx"
-  - "tmmn"
-  - "srad"
-  - "CAT_BASIN_SLOPE"
-  - "CAT_ELEV_MEAN"
-  - "CAT_BASIN_AREA"
-  - "CAT_IMPV11"
-  - "CAT_CNPY11_BUFF100"
-  - "CAT_TWI"
 y_vars:
   - "do_min"
   - "do_mean"

--- a/2a_model/src/models/0_baseline_LSTM/config.yml
+++ b/2a_model/src/models/0_baseline_LSTM/config.yml
@@ -1,8 +1,22 @@
+x_vars:
+  - "pr"
+  - "SLOPE"
+  - "tmmx"
+  - "tmmn"
+  - "srad"
+  - "CAT_BASIN_SLOPE"
+  - "CAT_ELEV_MEAN"
+  - "CAT_BASIN_AREA"
+  - "CAT_IMPV11"
+  - "CAT_CNPY11_BUFF100"
+  - "CAT_TWI"
+y_vars:
+  - "do_min"
+  - "do_mean"
+  - "do_max"
+lambdas:
+  - 1
+  - 1
+  - 1
 exp_name: "0_baseline_LSTM"
-
-x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
-
-y_vars: ['do_min', 'do_mean', 'do_max']
-
-lambdas: [1, 1, 1]
-
+ 

--- a/2a_model/src/models/1_metab_multitask/1a_multitask_do_gpp_er.yml
+++ b/2a_model/src/models/1_metab_multitask/1a_multitask_do_gpp_er.yml
@@ -1,16 +1,4 @@
 exp_name: "1a_multitask_do_gpp_er"
-x_vars:
-  - "pr"
-  - "SLOPE"
-  - "tmmx"
-  - "tmmn"
-  - "srad"
-  - "CAT_BASIN_SLOPE"
-  - "CAT_ELEV_MEAN"
-  - "CAT_BASIN_AREA"
-  - "CAT_IMPV11"
-  - "CAT_CNPY11_BUFF100"
-  - "CAT_TWI"
 y_vars:
   - "do_min"
   - "do_mean"

--- a/2a_model/src/models/1_metab_multitask/1b_multitask_do_gpp.yml
+++ b/2a_model/src/models/1_metab_multitask/1b_multitask_do_gpp.yml
@@ -1,16 +1,4 @@
 exp_name: "1b_multitask_do_gpp"
-x_vars:
-  - "pr"
-  - "SLOPE"
-  - "tmmx"
-  - "tmmn"
-  - "srad"
-  - "CAT_BASIN_SLOPE"
-  - "CAT_ELEV_MEAN"
-  - "CAT_BASIN_AREA"
-  - "CAT_IMPV11"
-  - "CAT_CNPY11_BUFF100"
-  - "CAT_TWI"
 y_vars:
   - "do_min"
   - "do_mean"

--- a/2a_model/src/models/1_metab_multitask/1b_multitask_do_gpp.yml
+++ b/2a_model/src/models/1_metab_multitask/1b_multitask_do_gpp.yml
@@ -1,4 +1,4 @@
-exp_name: "1a_multitask_do_gpp_er"
+exp_name: "1b_multitask_do_gpp"
 x_vars:
   - "pr"
   - "SLOPE"
@@ -25,7 +25,7 @@ lambdas:
   - 1
   - 1
   - 1
-  - 1
+  - 0
   - 0
   - 0
   - 0

--- a/2a_model/src/models/1_metab_multitask/2b_multitask_do_gpp.yml
+++ b/2a_model/src/models/1_metab_multitask/2b_multitask_do_gpp.yml
@@ -1,8 +1,0 @@
-exp_name: "1b_multitask_do_gpp"
-
-x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
-
-y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']
-
-lambdas: [1, 1, 1, 1, 0, 0, 0, 0]
-

--- a/2a_model/src/models/1_metab_multitask/config.yml
+++ b/2a_model/src/models/1_metab_multitask/config.yml
@@ -1,16 +1,4 @@
 exp_name: "1_metab_multitask"
-x_vars:
-  - "pr"
-  - "SLOPE"
-  - "tmmx"
-  - "tmmn"
-  - "srad"
-  - "CAT_BASIN_SLOPE"
-  - "CAT_ELEV_MEAN"
-  - "CAT_BASIN_AREA"
-  - "CAT_IMPV11"
-  - "CAT_CNPY11_BUFF100"
-  - "CAT_TWI"
 y_vars:
   - "do_min"
   - "do_mean"

--- a/2a_model/src/models/1_metab_multitask/config.yml
+++ b/2a_model/src/models/1_metab_multitask/config.yml
@@ -1,8 +1,32 @@
 exp_name: "1_metab_multitask"
-
-x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
-
-y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']
-
-lambdas: [1, 1, 1, 1, 1, 1, 1, 1]
-
+x_vars:
+  - "pr"
+  - "SLOPE"
+  - "tmmx"
+  - "tmmn"
+  - "srad"
+  - "CAT_BASIN_SLOPE"
+  - "CAT_ELEV_MEAN"
+  - "CAT_BASIN_AREA"
+  - "CAT_IMPV11"
+  - "CAT_CNPY11_BUFF100"
+  - "CAT_TWI"
+y_vars:
+  - "do_min"
+  - "do_mean"
+  - "do_max"
+  - "GPP"
+  - "ER"
+  - "K600"
+  - "depth"
+  - "temp.water"
+lambdas:
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+ 

--- a/2a_model/src/models/2_multitask_dense/config.yml
+++ b/2a_model/src/models/2_multitask_dense/config.yml
@@ -1,16 +1,4 @@
 exp_name: "2_multitask_dense"
-x_vars:
-  - "pr"
-  - "SLOPE"
-  - "tmmx"
-  - "tmmn"
-  - "srad"
-  - "CAT_BASIN_SLOPE"
-  - "CAT_ELEV_MEAN"
-  - "CAT_BASIN_AREA"
-  - "CAT_IMPV11"
-  - "CAT_CNPY11_BUFF100"
-  - "CAT_TWI"
 y_vars:
   - "do_min"
   - "do_mean"

--- a/2a_model/src/models/2_multitask_dense/config.yml
+++ b/2a_model/src/models/2_multitask_dense/config.yml
@@ -1,8 +1,32 @@
 exp_name: "2_multitask_dense"
-
-x_vars: ['pr','SLOPE','tmmx','tmmn','srad','CAT_BASIN_SLOPE','CAT_ELEV_MEAN','CAT_BASIN_AREA','CAT_IMPV11', 'CAT_CNPY11_BUFF100','CAT_TWI']
-
-y_vars: ['do_min', 'do_mean', 'do_max', 'GPP', 'ER', 'K600', 'depth', 'temp.water']
-
-lambdas: [1, 1, 1, 1, 1, 1, 1, 1]
-
+x_vars:
+  - "pr"
+  - "SLOPE"
+  - "tmmx"
+  - "tmmn"
+  - "srad"
+  - "CAT_BASIN_SLOPE"
+  - "CAT_ELEV_MEAN"
+  - "CAT_BASIN_AREA"
+  - "CAT_IMPV11"
+  - "CAT_CNPY11_BUFF100"
+  - "CAT_TWI"
+y_vars:
+  - "do_min"
+  - "do_mean"
+  - "do_max"
+  - "GPP"
+  - "ER"
+  - "K600"
+  - "depth"
+  - "temp.water"
+lambdas:
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+ 

--- a/2a_model/src/models/config_base.yml
+++ b/2a_model/src/models/config_base.yml
@@ -9,7 +9,7 @@ dropout: 0.2
 recurrent_dropout: 0.2
 finetune_learning_rate: 0.01
 early_stopping: False
-val_sites:
+validation_sites:
   - "01472104"
   - "01473500"
   - "01481500"
@@ -22,4 +22,15 @@ val_start_date: '2014-10-01'
 val_end_date: '2015-10-01'
 test_start_date: '2015-10-01'
 test_end_date: '2022-10-01'
+x_vars:
+  - "pr"
+  - "SLOPE"
+  - "tmmx"
+  - "tmmn"
+  - "srad"
+  - "CAT_BASIN_SLOPE"
+  - "CAT_ELEV_MEAN"
+  - "CAT_IMPV11"
+  - "CAT_CNPY11_BUFF100"
+  - "CAT_TWI"
  

--- a/2a_model/src/models/config_base.yml
+++ b/2a_model/src/models/config_base.yml
@@ -1,37 +1,25 @@
 out_dir: "../../../out/models"
-
-
-seed: False #random seed for training False==No seed, otherwise specify the seed
+seed: False
 num_replicates: 1
-
-
 trn_offset: 1.0
 tst_val_offset: 1.0
-
-#Define early stopping criteria, setting this to False will turn off early stopping rounds
-early_stopping: False
-
-train_start_date:
-  - '1980-10-01'
-train_end_date:
-  - '2014-10-01'
-val_start_date:
-  - '2014-10-01'
-val_end_date:
-  - '2015-10-01'
-test_start_date:
-  - '2015-10-01'
-test_end_date:
-  - '2022-10-01'
-
-validation_sites: ["01472104", "01473500", "01481500"]
-test_sites: ["01475530", "01475548"]
-
-
-epochs: [100]
-hidden_size: [10]
-
+epochs: 100
+hidden_size: 10
 dropout: 0.2
 recurrent_dropout: 0.2
 finetune_learning_rate: 0.01
-
+early_stopping: False
+val_sites:
+  - "01472104"
+  - "01473500"
+  - "01481500"
+test_sites:
+  - "01475530"
+  - "01475548"
+train_start_date: '1980-01-01'
+train_end_date: '2014-10-01'
+val_start_date: '2014-10-01'
+val_end_date: '2015-10-01'
+test_start_date: '2015-10-01'
+test_end_date: '2022-10-01'
+ 

--- a/2a_model/src/write_model_config_files.R
+++ b/2a_model/src/write_model_config_files.R
@@ -7,29 +7,39 @@
 #' @param cfg_options a list containing the model configuration parameters.
 #' @param fileout character string indicating the name of the saved yml file, 
 #' including file path and .yml extension.
+#' @param ... optional; additional parameters can be passed as inputs to the 
+#' model config file.
 #' 
 #' @return 
 #' Returns a saved yml file that contains all of the model inputs/parameters 
 #' that were passed to this function.
 #' 
-write_config_file <- function(cfg_options, fileout){
+write_config_file <- function(cfg_options, fileout, ...){
   
-  # Format select inputs/variables if they are included in cfg_options.
-  # Use silent = TRUE to suppress warnings and errors that appear if 
-  # one of the variables below is not included in cfg_options.
-  try(expr = {attr(cfg_options$out_dir, "quoted") <- TRUE}, silent = TRUE)
-  try(expr = {attr(cfg_options$model_save_dir, "quoted") <- TRUE}, silent = TRUE)
-  try(expr = {attr(cfg_options$val_sites, "quoted") <- TRUE}, silent = TRUE)
-  try(expr = {attr(cfg_options$test_sites, "quoted") <- TRUE}, silent = TRUE)
-  try(expr = {cfg_options$num_replicates <- as.integer(format(round(cfg_options$num_replicates,digits = 2),nsmall = 0))},
+  cfg_options_all <- c(cfg_options, list(...))
+  
+  # Format select inputs/variables if they are included in cfg_options. This
+  # is a little clunky, but we need to assign a non-null attribute to ensure
+  # a string scalar is quoted using yaml::as.yaml(). Use silent = TRUE to 
+  # suppress warnings and errors that appear if one of the variables below 
+  # is not included in cfg_options.
+  try(expr = {attr(cfg_options_all$out_dir, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$exp_name, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$val_sites, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$test_sites, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$x_vars, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$y_vars, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {cfg_options_all$num_replicates <- as.integer(format(round(cfg_options_all$num_replicates,digits = 2),nsmall = 0))},
       silent = TRUE)
-  try(expr = {cfg_options$epochs <- as.integer(format(round(cfg_options$epochs,digits = 2),nsmall = 0))},
+  try(expr = {cfg_options_all$epochs <- as.integer(format(round(cfg_options_all$epochs,digits = 2),nsmall = 0))},
       silent = TRUE)
-  try(expr = {cfg_options$hidden_size <- as.integer(format(round(cfg_options$hidden_size,digits = 2),nsmall = 0))},
+  try(expr = {cfg_options_all$hidden_size <- as.integer(format(round(cfg_options_all$hidden_size,digits = 2),nsmall = 0))},
+      silent = TRUE)
+  try(expr = {cfg_options_all$lambdas <- as.integer(format(round(cfg_options_all$lambdas,digits = 2),nsmall = 0))},
       silent = TRUE)
   
   # Save as yml 
-  out <- yaml::as.yaml(cfg_options, 
+  out <- yaml::as.yaml(cfg_options_all, 
                        # define how definitions should be indented
                        indent = 2,
                        indent.mapping.sequence = TRUE,

--- a/2a_model/src/write_model_config_files.R
+++ b/2a_model/src/write_model_config_files.R
@@ -8,7 +8,7 @@
 #' @param fileout character string indicating the name of the saved yml file, 
 #' including file path and .yml extension.
 #' @param ... optional; additional parameters can be passed as inputs to the 
-#' model config file.
+#' model config file such as the experiment name.
 #' 
 #' @return 
 #' Returns a saved yml file that contains all of the model inputs/parameters 
@@ -16,7 +16,7 @@
 #' 
 write_config_file <- function(cfg_options, fileout, ...){
   
-  cfg_options_all <- c(cfg_options, list(...))
+  cfg_options_all <- c(list(...), cfg_options)
   
   # Format select inputs/variables if they are included in cfg_options. This
   # is a little clunky, but we need to assign a non-null attribute to ensure

--- a/2a_model/src/write_model_config_files.R
+++ b/2a_model/src/write_model_config_files.R
@@ -1,0 +1,104 @@
+#' @title Write base model config file
+#' 
+#' @description 
+#' Function to take model inputs and parameters from that get defined in 
+#' _targets.R and write a base model configuration file.
+#' 
+#' @param fileout character string indicating the name of the saved yml file,
+#' including file name, path, and extension. 
+#' @param model_save_dir file directory where base model config file should
+#' be saved.
+#' @param seed logical, defaults to FALSE
+#' @param n_reps integer that indicates how many replicate model runs should be performed.
+#' @param trn_offset integer
+#' @param tst_val_offset integer
+#' @param early_stopping logical, defaults to FALSE
+#' @param epochs integer
+#' @param hidden_size integer
+#' @param dropout numeric
+#' @param recurrent_dropout numeric
+#' @param finetune_learning_rate numeric
+#' @param val_sites vector of character strings indicating the site numbers for those
+#' sites that should be withheld for model validation purposes.
+#' @param test_sites vector of character strings indicating the site numbers for those
+#' sites that should be withheld for model testing purposes.
+#' @param train_start_date character string indicating the earliest date of the model 
+#' training period, formatted as "YYYY-MM-DD."
+#' @param train_end_date character string indicating the latest date of the model 
+#' training period, formatted as "YYYY-MM-DD."
+#' @param val_start_date character string indicating the earliest date of the model 
+#' validation period, formatted as "YYYY-MM-DD."
+#' @param val_end_date character string indicating the latest date of the model
+#' validation period, formatted as "YYYY-MM-DD."
+#' @param test_start_date, character string indicating the earliest date of the model 
+#' test period, formatted as "YYYY-MM-DD."
+#' @param test_end_date character string indicating the latest date of the model
+#' test period, formatted as "YYYY-MM-DD."
+#' 
+#' @return 
+#' Returns a saved yml file that contains all of the model inputs/parameters 
+#' that were passed to this function.
+#' 
+write_base_config_file <- function(fileout, model_save_dir, 
+                                   seed = FALSE, n_reps, 
+                                   trn_offset, tst_val_offset, 
+                                   early_stopping = FALSE, 
+                                   epochs, hidden_size, dropout,
+                                   recurrent_dropout, finetune_learning_rate,
+                                   val_sites, test_sites,
+                                   train_start_date, train_end_date, 
+                                   val_start_date, val_end_date,
+                                   test_start_date, test_end_date){
+  
+  # Format select inputs/variables
+  attr(model_save_dir, "quoted") <- TRUE
+  attr(val_sites, "quoted") <- TRUE
+  attr(test_sites, "quoted") <- TRUE
+  n_reps <- as.integer(format(round(n_reps,digits = 2),nsmall = 0))
+  
+  # Define model inputs and parameters
+  cfg_inputs <- list(out_dir = model_save_dir, 
+                     seed = seed,
+                     num_replicates = n_reps,
+                     trn_offset = trn_offset,
+                     tst_val_offset = tst_val_offset,
+                     early_stopping = early_stopping,
+                     train_start_date = list(train_start_date),
+                     train_end_date = list(train_end_date),
+                     val_start_date = list(val_start_date),
+                     val_end_date = list(val_end_date),
+                     test_start_date = list(test_start_date),
+                     test_end_date = list(test_end_date),
+                     validation_sites = val_sites,
+                     test_sites = test_sites,
+                     epochs = epochs,
+                     hidden_size = hidden_size,
+                     dropout = dropout,
+                     recurrent_dropout = recurrent_dropout,
+                     finetune_learning_rate = finetune_learning_rate)
+  
+  # Save as yml 
+  out <- yaml::as.yaml(cfg_inputs, 
+                       # define how definitions should be indented
+                       indent = 2,
+                       indent.mapping.sequence = TRUE,
+                       # add special handlers 
+                       handlers = list(
+                         logical = function(x) {
+                           result <- ifelse(x, "True", "False")
+                           class(result) <- "verbatim"
+                           return(result)
+                           }
+                         ),
+                       )
+  
+  cat(out,"\n", file = fileout)
+  
+  return(fileout)
+
+}
+
+
+
+
+

--- a/2a_model/src/write_model_config_files.R
+++ b/2a_model/src/write_model_config_files.R
@@ -2,89 +2,41 @@
 #' 
 #' @description 
 #' Function to take model inputs and parameters from that get defined in 
-#' _targets.R and write a base model configuration file.
+#' _targets.R and write a model configuration file.
 #' 
-#' @param fileout character string indicating the name of the saved yml file,
-#' including file name, path, and extension. 
-#' @param model_save_dir file directory where base model config file should
-#' be saved.
-#' @param seed logical, defaults to FALSE
-#' @param n_reps integer that indicates how many replicate model runs should be performed.
-#' @param trn_offset integer
-#' @param tst_val_offset integer
-#' @param early_stopping logical, defaults to FALSE
-#' @param epochs integer
-#' @param hidden_size integer
-#' @param dropout numeric
-#' @param recurrent_dropout numeric
-#' @param finetune_learning_rate numeric
-#' @param val_sites vector of character strings indicating the site numbers for those
-#' sites that should be withheld for model validation purposes.
-#' @param test_sites vector of character strings indicating the site numbers for those
-#' sites that should be withheld for model testing purposes.
-#' @param train_start_date character string indicating the earliest date of the model 
-#' training period, formatted as "YYYY-MM-DD."
-#' @param train_end_date character string indicating the latest date of the model 
-#' training period, formatted as "YYYY-MM-DD."
-#' @param val_start_date character string indicating the earliest date of the model 
-#' validation period, formatted as "YYYY-MM-DD."
-#' @param val_end_date character string indicating the latest date of the model
-#' validation period, formatted as "YYYY-MM-DD."
-#' @param test_start_date, character string indicating the earliest date of the model 
-#' test period, formatted as "YYYY-MM-DD."
-#' @param test_end_date character string indicating the latest date of the model
-#' test period, formatted as "YYYY-MM-DD."
+#' @param cfg_options a list containing the model configuration parameters.
+#' @param fileout character string indicating the name of the saved yml file, 
+#' including file path and .yml extension.
 #' 
 #' @return 
 #' Returns a saved yml file that contains all of the model inputs/parameters 
 #' that were passed to this function.
 #' 
-write_base_config_file <- function(fileout, model_save_dir, 
-                                   seed = FALSE, n_reps, 
-                                   trn_offset, tst_val_offset, 
-                                   early_stopping = FALSE, 
-                                   epochs, hidden_size, dropout,
-                                   recurrent_dropout, finetune_learning_rate,
-                                   val_sites, test_sites,
-                                   train_start_date, train_end_date, 
-                                   val_start_date, val_end_date,
-                                   test_start_date, test_end_date){
+write_config_file <- function(cfg_options, fileout){
   
-  # Format select inputs/variables
-  attr(model_save_dir, "quoted") <- TRUE
-  attr(val_sites, "quoted") <- TRUE
-  attr(test_sites, "quoted") <- TRUE
-  n_reps <- as.integer(format(round(n_reps,digits = 2),nsmall = 0))
-  
-  # Define model inputs and parameters
-  cfg_inputs <- list(out_dir = model_save_dir, 
-                     seed = seed,
-                     num_replicates = n_reps,
-                     trn_offset = trn_offset,
-                     tst_val_offset = tst_val_offset,
-                     early_stopping = early_stopping,
-                     train_start_date = list(train_start_date),
-                     train_end_date = list(train_end_date),
-                     val_start_date = list(val_start_date),
-                     val_end_date = list(val_end_date),
-                     test_start_date = list(test_start_date),
-                     test_end_date = list(test_end_date),
-                     validation_sites = val_sites,
-                     test_sites = test_sites,
-                     epochs = epochs,
-                     hidden_size = hidden_size,
-                     dropout = dropout,
-                     recurrent_dropout = recurrent_dropout,
-                     finetune_learning_rate = finetune_learning_rate)
+  # Format select inputs/variables if they are included in cfg_options.
+  # Use silent = TRUE to suppress warnings and errors that appear if 
+  # one of the variables below is not included in cfg_options.
+  try(expr = {attr(cfg_options$out_dir, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options$model_save_dir, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options$val_sites, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options$test_sites, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {cfg_options$num_replicates <- as.integer(format(round(cfg_options$num_replicates,digits = 2),nsmall = 0))},
+      silent = TRUE)
+  try(expr = {cfg_options$epochs <- as.integer(format(round(cfg_options$epochs,digits = 2),nsmall = 0))},
+      silent = TRUE)
+  try(expr = {cfg_options$hidden_size <- as.integer(format(round(cfg_options$hidden_size,digits = 2),nsmall = 0))},
+      silent = TRUE)
   
   # Save as yml 
-  out <- yaml::as.yaml(cfg_inputs, 
+  out <- yaml::as.yaml(cfg_options, 
                        # define how definitions should be indented
                        indent = 2,
                        indent.mapping.sequence = TRUE,
-                       # add special handlers 
+                       # add special handlers to return logical values
+                       # with the specific formatting we want.
                        handlers = list(
-                         logical = function(x) {
+                         logical = function(x){
                            result <- ifelse(x, "True", "False")
                            class(result) <- "verbatim"
                            return(result)
@@ -97,8 +49,5 @@ write_base_config_file <- function(fileout, model_save_dir,
   return(fileout)
 
 }
-
-
-
 
 

--- a/2a_model/src/write_model_config_files.R
+++ b/2a_model/src/write_model_config_files.R
@@ -25,7 +25,7 @@ write_config_file <- function(cfg_options, fileout, ...){
   # is not included in cfg_options.
   try(expr = {attr(cfg_options_all$out_dir, "quoted") <- TRUE}, silent = TRUE)
   try(expr = {attr(cfg_options_all$exp_name, "quoted") <- TRUE}, silent = TRUE)
-  try(expr = {attr(cfg_options_all$val_sites, "quoted") <- TRUE}, silent = TRUE)
+  try(expr = {attr(cfg_options_all$validation_sites, "quoted") <- TRUE}, silent = TRUE)
   try(expr = {attr(cfg_options_all$test_sites, "quoted") <- TRUE}, silent = TRUE)
   try(expr = {attr(cfg_options_all$x_vars, "quoted") <- TRUE}, silent = TRUE)
   try(expr = {attr(cfg_options_all$y_vars, "quoted") <- TRUE}, silent = TRUE)

--- a/_targets.R
+++ b/_targets.R
@@ -110,7 +110,7 @@ base_config_options <- list(
   finetune_learning_rate = 0.01,
   early_stopping = FALSE,
   # train/val/test split information is defined above:
-  val_sites = val_sites, 
+  validation_sites = val_sites, 
   test_sites = tst_sites,
   train_start_date = train_start_date, 
   train_end_date = train_end_date, 
@@ -122,7 +122,7 @@ base_config_options <- list(
 
 # Define global model parameters for the "baseline" deep learning model
 x_vars_global <- c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
-                   "CAT_BASIN_AREA","CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI")
+                   "CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI")
 
 # Model 0: Create a list that contains inputs for the "baseline" deep learning model
 model_config_options <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -94,18 +94,32 @@ val_end_date <- '2015-10-01'
 test_start_date <- '2015-10-01'
 test_end_date <- '2022-10-01'
 
-# Define model parameters
-n_model_reps <- 1
-trn_offset <- 1
-tst_val_offset <- 1
-epochs <- 100
-hidden_size <- 10
-dropout <- 0.2
-recurrent_dropout <- 0.2
-finetune_learning_rate <- 0.01
-# random seed for training False==No seed, otherwise specify the seed
-seed <- FALSE
-early_stopping <- FALSE
+# Define model parameters and combine within a list that gets
+# used to write a model config file that gets passed to the 
+# snakemake modeling workflow.
+base_config_options <- list(
+  out_dir = "../../../out/models",
+  # random seed for training; If FALSE, no seed. Otherwise, specify the seed:
+  seed = FALSE,
+  num_replicates = 1,
+  trn_offset = 1,
+  tst_val_offset = 1,
+  epochs = 100,
+  hidden_size = 10,
+  dropout = 0.2,
+  recurrent_dropout = 0.2,
+  finetune_learning_rate = 0.01,
+  early_stopping = FALSE,
+  # train/val/test split information is defined above:
+  val_sites = val_sites, 
+  test_sites = tst_sites,
+  train_start_date = train_start_date, 
+  train_end_date = train_end_date, 
+  val_start_date = val_start_date, 
+  val_end_date = val_end_date,
+  test_start_date = test_start_date, 
+  test_end_date = test_end_date
+  )
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p2a_targets_list, p3_targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -94,9 +94,8 @@ val_end_date <- '2015-10-01'
 test_start_date <- '2015-10-01'
 test_end_date <- '2022-10-01'
 
-# Define model parameters and combine within a list that gets
-# used to write a model config file that gets passed to the 
-# snakemake modeling workflow.
+# Define model parameters and combine within a list that gets used to
+# write a base model config file for the snakemake modeling workflow.
 base_config_options <- list(
   out_dir = "../../../out/models",
   # random seed for training; If FALSE, no seed. Otherwise, specify the seed:
@@ -121,12 +120,38 @@ base_config_options <- list(
   test_end_date = test_end_date
   )
 
+# Define global model parameters for the "baseline" deep learning model
+x_vars_global <- c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
+                   "CAT_BASIN_AREA","CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI")
+
+# Model 0: Create a list that contains inputs for the "baseline" deep learning model
 model_config_options <- list(
-  x_vars = c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
-             "CAT_BASIN_AREA","CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI"),
+  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max"),
   lambdas = c(1,1,1)
 )
+
+# Model 1: Create a list that contains inputs for the metab_multitask model
+metab_multitask_config_options <- list(
+  x_vars = x_vars_global,
+  y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
+  lambdas = c(1, 1, 1, 1, 1, 1, 1, 1)
+)
+
+# Model 1a: Create a list that contains inputs for the 1a_metab_multitask model
+metab_1a_multitask_config_options <- list(
+  x_vars = x_vars_global,
+  y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
+  lambdas = c(1, 1, 1, 1, 1, 0, 0, 0)
+)
+
+# Model 1b: Create a list that contains inputs for the 1b_metab_multitask model
+metab_1b_multitask_config_options <- list(
+  x_vars = x_vars_global,
+  y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
+  lambdas = c(1, 1, 1, 1, 0, 0, 0, 0)
+)
+
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p2a_targets_list, p3_targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -5,7 +5,7 @@ tar_option_set(packages = c("tidyverse", "lubridate", "rmarkdown", "knitr",
                             "dataRetrieval", "nhdplusTools", "sbtools",
                             "leaflet", "sf", "USAboundaries", "cowplot",
                             "ggspatial", "patchwork", "streamMetabolizer", 
-                            "reticulate"))
+                            "reticulate", "yaml"))
 
 source("1_fetch.R")
 source("2_process.R")
@@ -20,6 +20,8 @@ dir.create("2_process/log/", showWarnings = FALSE)
 dir.create("3_visualize/out/", showWarnings = FALSE)
 dir.create("3_visualize/out/nhdv2_attr_png/", showWarnings = FALSE)
 dir.create("3_visualize/log/", showWarnings = FALSE)
+
+# 1) Configure data pipeline inputs/variables
 
 # Define columns of interest from harmonized WQP data
 wqp_vars_select <- c("MonitoringLocationIdentifier", "MonitoringLocationName",
@@ -78,16 +80,32 @@ min_obs_days <- 100
 # Change dummy date to force re-build of NWIS DO sites and data download
 dummy_date <- "2022-06-15"
 
-# test and validation sites
+
+#2) Configure model inputs/variables 
+
+# Define test and validation sites
 val_sites <- c("01472104", "01473500", "01481500")
 tst_sites <- c("01475530", "01475548")
 
 train_start_date <- '1980-01-01'
-train_end_date <- '2017-01-01'
-val_start_date <- '2017-01-01'
-val_end_date <- '2019-01-01'
-test_start_date <- '2019-01-01'
-test_end_date <- '2022-01-01'
+train_end_date <- '2014-10-01'
+val_start_date <- '2014-10-01'
+val_end_date <- '2015-10-01'
+test_start_date <- '2015-10-01'
+test_end_date <- '2022-10-01'
+
+# Define model parameters
+n_model_reps <- 1
+trn_offset <- 1
+tst_val_offset <- 1
+epochs <- 100
+hidden_size <- 10
+dropout <- 0.2
+recurrent_dropout <- 0.2
+finetune_learning_rate <- 0.01
+# random seed for training False==No seed, otherwise specify the seed
+seed <- FALSE
+early_stopping <- FALSE
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p2a_targets_list, p3_targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -152,6 +152,13 @@ metab_1b_multitask_config_options <- list(
   lambdas = c(1, 1, 1, 1, 0, 0, 0, 0)
 )
 
+# Model 2: Create a list that contains inputs for the metab_dense model
+multitask_dense_config_options <- list(
+  x_vars = x_vars_global,
+  y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
+  lambdas = c(1, 1, 1, 1, 1, 1, 1, 1)
+)
+
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p2a_targets_list, p3_targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -121,6 +121,13 @@ base_config_options <- list(
   test_end_date = test_end_date
   )
 
+model_config_options <- list(
+  x_vars = c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
+             "CAT_BASIN_AREA","CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI"),
+  y_vars = c("do_min","do_mean","do_max"),
+  lambdas = c(1,1,1)
+)
+
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p2a_targets_list, p3_targets_list)
 

--- a/_targets.R
+++ b/_targets.R
@@ -87,12 +87,17 @@ dummy_date <- "2022-06-15"
 val_sites <- c("01472104", "01473500", "01481500")
 tst_sites <- c("01475530", "01475548")
 
+# Define train/val/test dates
 train_start_date <- '1980-01-01'
 train_end_date <- '2014-10-01'
 val_start_date <- '2014-10-01'
 val_end_date <- '2015-10-01'
 test_start_date <- '2015-10-01'
 test_end_date <- '2022-10-01'
+
+# Define global model parameters for the "baseline" deep learning model
+x_vars_global <- c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
+                   "CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI")
 
 # Define model parameters and combine within a list that gets used to
 # write a base model config file for the snakemake modeling workflow.
@@ -117,44 +122,40 @@ base_config_options <- list(
   val_start_date = val_start_date, 
   val_end_date = val_end_date,
   test_start_date = test_start_date, 
-  test_end_date = test_end_date
+  test_end_date = test_end_date,
+  x_vars = x_vars_global
   )
 
-# Define global model parameters for the "baseline" deep learning model
-x_vars_global <- c("pr","SLOPE","tmmx","tmmn","srad","CAT_BASIN_SLOPE","CAT_ELEV_MEAN",
-                   "CAT_IMPV11","CAT_CNPY11_BUFF100","CAT_TWI")
+# Configure individual models. If different x_vars are desired, add
+# `x_vars = [vector of attribute names]` to any of the config options
+# lists below, which will override `x_vars_global` in `base_config_options`.
 
-# Model 0: Create a list that contains inputs for the "baseline" deep learning model
+# Model 0: Create a list that contains inputs for the "baseline" deep learning model.
 model_config_options <- list(
-  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max"),
   lambdas = c(1,1,1)
 )
 
 # Model 1: Create a list that contains inputs for the metab_multitask model
 metab_multitask_config_options <- list(
-  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
   lambdas = c(1, 1, 1, 1, 1, 1, 1, 1)
 )
 
 # Model 1a: Create a list that contains inputs for the 1a_metab_multitask model
 metab_1a_multitask_config_options <- list(
-  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
   lambdas = c(1, 1, 1, 1, 1, 0, 0, 0)
 )
 
 # Model 1b: Create a list that contains inputs for the 1b_metab_multitask model
 metab_1b_multitask_config_options <- list(
-  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
   lambdas = c(1, 1, 1, 1, 0, 0, 0, 0)
 )
 
 # Model 2: Create a list that contains inputs for the metab_dense model
 multitask_dense_config_options <- list(
-  x_vars = x_vars_global,
   y_vars = c("do_min","do_mean","do_max","GPP","ER","K600","depth","temp.water"),
   lambdas = c(1, 1, 1, 1, 1, 1, 1, 1)
 )


### PR DESCRIPTION
This PR addresses #160, which notes that we currently define `val_times` in two separate places, in `_targets.R` and in `2a_model/src/models/config_base.yml` (and right now the `val_times` differ between these two places). 

For purposes of interpretability and avoiding bugs, I think we should try to avoid situations where we're defining model parameters in multiple places. We could omit `val_times` from `_targets.R`, although those variables currently get passed to visualization/plotting functions. 

`_targets.R` acts as a config file for the rest of the data-model pipeline, so I've also wondered whether we should just define our model parameters there, and have a target that writes the config files to a yml. This way, `_targets.R` is a kind of one-stop shop for all model inputs and parameters. I've implemented this for the baseline model config file in this draft PR. I would appreciate your ideas, @jsadler2 and @galengorski, on 1) whether this is useful, overkill, both(?); 2) if useful, one question I would have is whether the block style formatting (see `val_sites` and `test_sites` below) would work. I don't know how I can write the parameters using the 'flow-style' sequence formatting (e.g. `val_sites = ["x","y","z"]`) that's currently included in the config files.

Here's what the output config would look like for the baseline model:

```py
out_dir: "../../../out/models"
seed: False
num_replicates: 1
trn_offset: 1.0
tst_val_offset: 1.0
early_stopping: False
train_start_date:
  - '1980-01-01'
train_end_date:
  - '2014-10-01'
val_start_date:
  - '2014-10-01'
val_end_date:
  - '2015-10-01'
test_start_date:
  - '2015-10-01'
test_end_date:
  - '2022-10-01'
validation_sites:
  - "01472104"
  - "01473500"
  - "01481500"
test_sites:
  - "01475530"
  - "01475548"
epochs: 100.0
hidden_size: 10.0
dropout: 0.2
recurrent_dropout: 0.2
finetune_learning_rate: 0.01
```

