### PR TITLE
Plot segment/catchment attributes

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -73,9 +73,8 @@ p2_targets_list <- list(
   tar_target(
     p2_sites_w_segs,
     {
-      
-    # Flowlines with no catchments do not have any associated climate driver data, 
-    # so omit any flowlines where AREASQKM == 0 before matching sites to reaches.
+      # Flowlines with no catchments do not have any associated climate driver data, 
+      # so omit any flowlines where AREASQKM == 0 before matching sites to reaches.
       nhd_reaches_w_cats <- p1_nhd_reaches_sf %>%
         filter(AREASQKM > 0)
       sites_w_segs <- get_site_nhd_flowlines(nhd_lines = nhd_reaches_w_cats, 
@@ -188,10 +187,7 @@ p2_targets_list <- list(
  tar_target(
    p2_seg_attr_data,
    combine_nhdv2_attr(nhd_vaa = p2_nhdv2_vaa_attr, 
-                      cat_attr_list = p2_cat_attr_list,
-                      sites_w_segs = filter(p2_sites_w_segs,
-                                            COMID %in% p2_well_observed_reaches$COMID)
-                      )
+                      cat_attr_list = p2_cat_attr_list)
  ),
  
  # Subset the DRB meteorological data to only include the NHDPlusv2 catchments (COMID)

--- a/2_process/src/process_nhdv2_attributes.R
+++ b/2_process/src/process_nhdv2_attributes.R
@@ -126,10 +126,8 @@ process_nhdv2_vaa <- function(nhd_lines, vaa_cols){
 #' Must contain column "COMID".
 #' @param cat_attr_list list object containing different catchment attribute
 #' data frames.
-#' @param sites_w_segs data frame containing observation locations with 
-#' their matched flowlines. Must contain column "COMID".
 #'
-combine_nhdv2_attr <- function(nhd_vaa, cat_attr_list, sites_w_segs){
+combine_nhdv2_attr <- function(nhd_vaa, cat_attr_list){
   
   # Combine list object containing catchment attributes into a single data frame
   cat_attr_df <- cat_attr_list %>%
@@ -142,12 +140,8 @@ combine_nhdv2_attr <- function(nhd_vaa, cat_attr_list, sites_w_segs){
   attr_data <- nhd_vaa %>%
     mutate(COMID = as.character(COMID)) %>%
     left_join(y = cat_attr_df, by = "COMID")
-  
-  # Subset attribute data to the flowline reaches with observations
-  attr_data_sub <- attr_data %>%
-    filter(COMID %in% unique(sites_w_segs$COMID))
     
-  return(attr_data_sub)
+  return(attr_data)
   
 }
 

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -4,6 +4,7 @@ source("3_visualize/src/plot_daily_data.R")
 source("3_visualize/src/plot_inst_data.R")
 source("3_visualize/src/do_overview_plots.R")
 source("3_visualize/src/summarize_static_attributes.R")
+source("3_visualize/src/plot_nhdv2_attr.R")
 source("3_visualize/src/map_sites.R")
 
 p3_targets_list <- list(
@@ -13,6 +14,19 @@ p3_targets_list <- list(
                           path = "3_visualize/src/report-do-inventory.Rmd",
                           output_dir = "3_visualize/out"),
   
+  # Visualize segment/catchment attributes across the DRB and across sites.
+  tar_target(
+    p3_nhdv2_attr_png,
+    plot_nhdv2_attr(attr_data = p2_seg_attr_data,
+                    network_geometry = p1_nhd_reaches_sf,
+                    save_dir = "3_visualize/out/nhdv2_attr_png",
+                    plot_sites = TRUE, 
+                    sites = p2_sites_w_segs %>%
+                      filter(site_id %in% p2_well_observed_sites), 
+                    sites_epsg = 4269),
+    format = "file"
+  ),
+  
   # Generate summary plots (all daily and inst data)
   tar_target(
     p3_daily_summary_plot_png,
@@ -20,14 +34,12 @@ p3_targets_list <- list(
                     fig_cols = 5, fig_width = 8, fig_height = 7),
     format = "file"
   ),
-  
   tar_target(
     p3_inst_summary_plot_png,
     plot_daily_data(p1_inst_data, fileout = "3_visualize/out/inst_daily_means.png",
                     fig_cols = 4, fig_width = 6, fig_height = 7),
     format = "file"
   ),
-  
   tar_target(
     p3_doy_means_png,
     plot_doy_means(p2_daily_combined,fileout = "3_visualize/out/doy_means.png",
@@ -43,7 +55,6 @@ p3_targets_list <- list(
                     fig_cols = 1, fig_width = 4, fig_height = 10),
     format = "file"
   ),
-  
   tar_target(
     p3_inst_summary_plot_filtered_png,
     plot_daily_data(p1_inst_data, fileout = "3_visualize/out/filtered_inst_means.png",
@@ -52,9 +63,11 @@ p3_targets_list <- list(
   ),
 
   # Save a table containing summary statistics for the NHDPlusv2 static attributes
+  # across the well-observed reaches used for modeling. 
   tar_target(
     p3_static_attr_summary_csv,
-    summarize_static_attributes(p2_seg_attr_data, "3_visualize/out/nhdv2_static_attr_summary.csv"),
+    summarize_static_attributes(filter(p2_seg_attr_data, COMID %in% p2_well_observed_reaches$COMID), 
+                                "3_visualize/out/nhdv2_static_attr_summary.csv"),
     format = "file"
   ),
   

--- a/3_visualize/src/plot_nhdv2_attr.R
+++ b/3_visualize/src/plot_nhdv2_attr.R
@@ -1,0 +1,134 @@
+#' @title Plot segment and catchment attributes
+#' 
+#' @description 
+#' This function visualizes each of the NHDPlusv2 attribute variables across
+#' all river segments within the network.
+#' 
+#' @details 
+#' This function was originally developed as part of the drb-inland-salinity-ml 
+#' project:
+#' https://github.com/USGS-R/drb-inland-salinity-ml/blob/synoptic_site_viz/3_visualize/src/plot_nhdv2_attr.R
+#'
+#' @param attr_data data frame containing the processed NHDv2 attribute data; 
+#' must include column "COMID".
+#' @param network_geometry sf object containing the network flowline geometry; 
+#' must include columns "COMID" and "geometry".
+#' @param save_dir character string indicating where the directory where the
+#' output plots should be saved.
+#' @param plot_sites logical; indicates whether or not to plot sampling sites.
+#' @param sites tbl with the sampling sites and columns for the corresponding "COMID".
+#' @param sites_epsg integer indicating the epsg code in the sites table 
+#' (i.e., 4269 for NAD83).
+#'
+#' @returns 
+#' Saves a png file containing a violin plot showing the distribution of each 
+#' NHDv2 attribute variable and returns the file path of the saved file. 
+#' 
+plot_nhdv2_attr <- function(attr_data,
+                            network_geometry,
+                            save_dir,
+                            plot_sites = FALSE, 
+                            sites = NULL, 
+                            sites_epsg = NULL){
+
+  if(plot_sites){
+    if (is.null(sites)){
+      stop('sites must be specified when plot_sites = TRUE')
+    }
+    if (is.null(sites_epsg)){
+      stop('sites CRS (as epsg code) must be specified when plot_sites = TRUE')
+    }
+    # Create spatial dataframe
+    sites_sf <- sf::st_as_sf(sites, coords = c('lon', 'lat'), crs = sites_epsg) 
+    
+    # add indicator to attr_data for reaches that have sites
+    attr_data_ind <- attr_data %>%
+      mutate(site_reaches = case_when(COMID %in% sites_sf$COMID ~ 1,
+                                      TRUE ~ 0))
+  }
+  
+  message("Plotting individual NHDv2 attribute variables...")
+  
+  plot_names <- vector('character', length = 0L)
+  
+  # For each column/attribute variable, plot the distribution of the data 
+  # across all NHDPlusv2 segments
+  attr_names <- names(attr_data)[names(attr_data) != "COMID"]
+  
+  for(i in seq_along(attr_names)){
+    col_name <- attr_names[i]
+    subset_cols <- c("COMID", col_name, "site_reaches")
+    
+    if(plot_sites){
+      dat_subset <- attr_data_ind %>%
+        select(any_of(subset_cols))
+
+      # plot the distribution of attr values on a linear scale
+      attr_plot <- dat_subset %>%
+        ggplot(aes(x = "", y = .data[[col_name]])) + 
+        geom_violin(draw_quantiles = c(0.5)) +
+        geom_jitter(data = dat_subset[dat_subset$site_reaches == 0,],
+                    height = 0, 
+                    size = 0.5,
+                    color = "steelblue",
+                    alpha = 0.1, width = 0.2) +
+        geom_jitter(data = dat_subset[dat_subset$site_reaches == 1,],
+                    height = 0, 
+                    color = "red",
+                    alpha = 0.4, width = 0.2) +
+        labs(x="") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,0), "cm"))
+      
+      # plot the spatial variation
+      attr_plot_spatial <- dat_subset %>% 
+        mutate(COMID = as.integer(COMID)) %>%
+        left_join(.,network_geometry[,c("COMID","geometry")],by=c("COMID"="COMID")) %>%
+        sf::st_as_sf() %>%
+        ggplot() + 
+        geom_sf(aes(color=.data[[col_name]]), size = 0.3) + 
+        scale_color_viridis_c(option="plasma") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,2), "cm"),
+              axis.text.x = element_text(size = 6),
+              legend.title = element_text(size = 10)) +
+        geom_sf(data = sites_sf, size = 0.3)
+    } else {
+      dat_subset <- attr_data %>%
+        select(any_of(subset_cols))
+      
+      # plot the distribution of attr values on a linear scale
+      attr_plot <- dat_subset %>%
+        ggplot(aes(x = "", y = .data[[col_name]])) + 
+        geom_violin(draw_quantiles = c(0.5)) +
+        geom_jitter(height = 0, color = "steelblue", size = 0.5, alpha = 0.4, width = 0.2) +
+        labs(x="") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,0), "cm"))
+      
+      # plot the spatial variation
+      attr_plot_spatial <- dat_subset %>% 
+        mutate(COMID = as.integer(COMID)) %>%
+        left_join(.,network_geometry[,c("COMID","geometry")],by = c("COMID" = "COMID")) %>%
+        sf::st_as_sf() %>%
+        ggplot() + 
+        geom_sf(aes(color = .data[[col_name]]), size = 0.3) + 
+        scale_color_viridis_c(option="plasma") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,2), "cm"),
+              axis.text.x = element_text(size = 6),
+              legend.title = element_text(size = 10))
+    }
+    
+    # create combined plot showing violin plot and spatial distribution
+    attr_plot_combined <- attr_plot + attr_plot_spatial + patchwork::plot_layout(ncol=2)
+    
+    plot_name <- paste0(save_dir,"/",col_name,".png")
+    plot_names <- c(plot_names,plot_name)
+    
+    suppressWarnings(ggsave(plot_name,plot = attr_plot_combined,width = 7,height = 4,device = "png"))
+  }
+  
+  return(plot_names)
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -18,6 +18,7 @@ dir.create("2_process/out/", showWarnings = FALSE)
 dir.create("2a_model/out/", showWarnings = FALSE)
 dir.create("2_process/log/", showWarnings = FALSE)
 dir.create("3_visualize/out/", showWarnings = FALSE)
+dir.create("3_visualize/out/nhdv2_attr_png/", showWarnings = FALSE)
 dir.create("3_visualize/log/", showWarnings = FALSE)
 
 # Define columns of interest from harmonized WQP data

--- a/_targets.R
+++ b/_targets.R
@@ -4,7 +4,8 @@ options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "lubridate", "rmarkdown", "knitr",
                             "dataRetrieval", "nhdplusTools", "sbtools",
                             "leaflet", "sf", "USAboundaries", "cowplot",
-                            "ggspatial", "streamMetabolizer", "reticulate"))
+                            "ggspatial", "patchwork", "streamMetabolizer", 
+                            "reticulate"))
 
 source("1_fetch.R")
 source("2_process.R")


### PR DESCRIPTION
This PR creates plots to quickly visualize the segment/catchment attributes that were downloaded and processed. These plots are meant to help understand the input features and aid feature selection. 

A new function, `plot_nhdv2_attr()`, plots the distribution of attribute values as well as their spatial distribution in the lower DRB. The function is used in a new target in `3_visualize.R` - `p3_nhdv2_attr_png` - which saves those plots to a folder in 3_visualize/out.

Here's an example of the plots that are generated by the code changes in this PR:

![CAT_CLAYAVE](https://user-images.githubusercontent.com/8785034/196960783-e16375c3-7566-4990-ab04-e8bf74d7e6d4.png)

