### PR TITLE
Edit date formatting in Snakefile_base.smk

### DIFF
--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -128,22 +128,22 @@ def filter_predictions(all_preds_file, partition, out_file):
 
 
         if partition == "trn":
-            df_preds_filt = df_preds_trn_sites[(df_preds_trn_sites.date >= config['train_start_date'][0]) &
-                                               (df_preds_trn_sites.date < config['train_end_date'][0])]
+            df_preds_filt = df_preds_trn_sites[(df_preds_trn_sites.date >= config['train_start_date']) &
+                                               (df_preds_trn_sites.date < config['train_end_date'])]
         elif partition == "val":
             # get all of the data in the validation sites and in the validation period
             # this assumes that the test period follows the validation period which follows the train period
-            df_preds_filt_val = df_preds_val_sites[df_preds_val_sites.date < config['test_start_date'][0]]
-            df_preds_filt_trn = df_preds_trn_sites[(df_preds_trn_sites.date < config['val_end_date'][0]) &
-                                                   (df_preds_trn_sites.date >= config['val_start_date'][0])]
+            df_preds_filt_val = df_preds_val_sites[df_preds_val_sites.date < config['test_start_date']
+            df_preds_filt_trn = df_preds_trn_sites[(df_preds_trn_sites.date < config['val_end_date']) &
+                                                   (df_preds_trn_sites.date >= config['val_start_date'])]
             df_preds_filt = pd.concat([df_preds_filt_val , df_preds_filt_trn], axis=0)
 
         elif partition == "val_times":
             # get the data in just the validation times at train and val sites
-            df_preds_filt_val = df_preds_val_sites[(df_preds_val_sites.date < config['val_end_date'][0]) &
-                                                   (df_preds_val_sites.date >= config['val_start_date'][0])]
-            df_preds_filt_trn = df_preds_trn_sites[(df_preds_trn_sites.date < config['val_end_date'][0]) &
-                                                   (df_preds_trn_sites.date >= config['val_start_date'][0])]
+            df_preds_filt_val = df_preds_val_sites[(df_preds_val_sites.date < config['val_end_date']) &
+                                                   (df_preds_val_sites.date >= config['val_start_date'])]
+            df_preds_filt_trn = df_preds_trn_sites[(df_preds_trn_sites.date < config['val_end_date']) &
+                                                   (df_preds_trn_sites.date >= config['val_start_date'])]
             df_preds_filt = pd.concat([df_preds_filt_val , df_preds_filt_trn], axis=0)
 
 


### PR DESCRIPTION
This PR includes changes to the `filter_predictions` rule in `2a_model/src/models/Snakefile_base.smk` to reflect that the train/val/test start and end dates are formatted as length = 1 in the configuration files (not a list). The newly formatted lines mirror what is used in the `prep_io_data` rule within the same smk file.

Before making these changes to the smk file I did try to format the train/val/test dates in `_targets.R` to coerce the dates as a "list" but without much luck. And unless we expect to include multiple dates for the train/val/test splits these changes to the smk file seemed more straightforward. 

Do you mind looking this over, @jsadler2? If you're taking a look at the smk files, it might make sense to chime in on #171 too.

Closes #172 