### PR TITLE
Replace hard-coded prediction dates in Snakefile_base.smk

### DIFF
--- a/2a_model/src/models/Snakefile_base.smk
+++ b/2a_model/src/models/Snakefile_base.smk
@@ -107,8 +107,8 @@ rule make_predictions:
         weight_dir = input[1] + "/"
         params.model.load_weights(weight_dir)
         preds = predict_from_arbitrary_data(raw_data_file=input[2],
-                                            pred_start_date="1980-01-01",
-                                            pred_end_date="2019-01-01",
+                                            pred_start_date = config['train_start_date'],
+                                            pred_end_date = config['val_end_date'],
                                             train_io_data=input[0],
                                             model=params.model, 
                                             spatial_idx_name='site_id',


### PR DESCRIPTION
This is a small PR to replace hard-coded start and end dates for the predictions step in `Snakefile_base.smk` with dates that get pulled from the config files. I tried running the pipeline with this edit on tallgrass and it seemed to work fine. 

@jsadler2, can you remind me why the `pred_end_date` is equal to the `val_end_date` (as opposed to the `test_end_date`)?

Closes #171.