### PR TITLE
add TE at zero lag functionality

### DIFF
--- a/2a_model/src/it_functions.py
+++ b/2a_model/src/it_functions.py
@@ -208,14 +208,23 @@ def lag_data(M, shift):
     
     length_M = M.shape[0]
     cols_M = M.shape[1]
-
-    #this is for => H(Xt-T, Yt, Yt-T)
-    newlength_M = length_M - shift
-    M_lagged = np.nan*np.ones([newlength_M, cols_M+1])
-    M_lagged[:,0] = M[:(length_M-shift),0]
-    M_lagged[:,1] = M[shift:(length_M)+1,1]
-    M_lagged[:,2] = M[:(length_M-shift),1]
     
+    if shift == 0:
+        #this is for => H(Xt-t, Yt, Yt-1) with shift = 0
+        newlength_M = length_M - 1
+        M_lagged = np.nan*np.ones([newlength_M, cols_M+1])
+        M_lagged[:,0] = M[:(newlength_M),0]
+        M_lagged[:,1] = M[:(newlength_M),1]
+        M_lagged[:,2] = M[1:(length_M),1]
+
+    else:
+        #this is for => H(Xt-T, Yt, Yt-T)
+        newlength_M = length_M - shift
+        M_lagged = np.nan*np.ones([newlength_M, cols_M+1])
+        M_lagged[:,0] = M[:(length_M-shift),0]
+        M_lagged[:,1] = M[shift:(length_M)+1,1]
+        M_lagged[:,2] = M[:(length_M-shift),1]
+        
     return M_lagged
 
 def calcTE(M, shift, nbins):


### PR DESCRIPTION
This includes a small bit of code to add functionality to calculate transfer entropy (TE) at a time lag of zero. Previously we had been calculating TE by calculating the relationship between source (X) and sink (Y) as : 
![image](https://user-images.githubusercontent.com/32860978/214337990-d5190b3d-9839-47bd-9218-00cac97c8243.png)

where the time series of X and Y lagged at some time step tau. However, if tau = 0, then this formulation will lead to a TE of 0 because you are marginalizing out the whole time series. So the change that I propose is to use the above formulation for all tau not equal to zero and for tau = 0 to marginalize the t-1 lagged time series, so:

![image](https://user-images.githubusercontent.com/32860978/214338815-e02e5611-aa2f-4f6e-8dbc-7761fbafeaf0.png)
