### PR TITLE
Edit site map

### DIFF
--- a/2a_model.R
+++ b/2a_model.R
@@ -45,7 +45,8 @@ p2a_targets_list <- list(
         sf::st_as_sf(., coords = c("lon","lat"), crs = unique(.$epsg))
       
       append_river_km(site_splits, p1_nhd_reaches_sf) %>%
-        mutate(river_basin_abbr = case_when(river_basin == "Schuylkill" ~ "SR",
+        mutate(river_dist_km = round(river_dist_km, 0),
+               river_basin_abbr = case_when(river_basin == "Schuylkill" ~ "SR",
                                             river_basin == "Brandywine" ~ "BC",
                                             river_basin == "Cobbs" ~ "CC",
                                             site_id %in% c("014721254") ~ "FC",

--- a/2a_model/src/format_site_splits.R
+++ b/2a_model/src/format_site_splits.R
@@ -1,0 +1,87 @@
+#' @title Append river distance
+#' 
+#' @description
+#' Appends the downstream river distance (in km) to the sites_splits table
+#' 
+#' @param sites_splits data frame; must contain column "river_basin"
+#' @param nhdv2_flines sf (MULTI)LINESTRING object; must contain columns "COMID",
+#' "GNIS_NAME", and "LEVELPATHI"
+#' 
+#' @returns 
+#' Returns the sites_splits data frame, with a new column, "river_dist_km"
+#' 
+append_river_km <- function(sites_splits, nhdv2_flines){
+  
+  lapply(split(sites_splits, 1:nrow(sites_splits)), function(x){
+    
+    if(x$river_basin == "Brandywine"){
+      flines_sub <- filter(nhdv2_flines, grepl("brandywine", GNIS_NAME, ignore.case = TRUE))
+    }
+    if(x$river_basin == "Schuylkill"){
+      flines_sub <- filter(nhdv2_flines, grepl("schuylkill", GNIS_NAME, ignore.case = TRUE))
+    }
+    if(x$river_basin == "Cobbs"){
+      flines_sub <- filter(nhdv2_flines, LEVELPATHI == 200057760)
+    }
+    if(!x$river_basin %in% c("Brandywine", "Schuylkill", "Cobbs")){
+      mutate(x, river_dist_km = NA_real_)
+    } else {
+      mutate(x, river_dist_km = get_river_km(x, flines_sub))
+    }
+  }) |>
+    bind_rows()
+  
+}
+
+
+
+#' @title Get downstream river length
+#' 
+#' @description 
+#' Given a point location, subsets the river length downstream of the point and
+#' returns the length in kilometers
+#' 
+#' @param pt sf POINT object; must contain column "COMID"
+#' @param flines sf LINESTRING object; must contain column "COMID"
+#' 
+#' @returns 
+#' Returns numeric length (in km) of the mainstem distance from the point 
+#' location to the outlet.
+#' 
+get_river_km <- function(pt, flines){
+  
+  flines <- sf::st_transform(flines, 5070)
+  pt <- sf::st_transform(pt, 5070)
+  
+  fline_pt <- filter(flines, COMID %in% pt$COMID)
+  flines_down <- nhdplusTools::navigate_network(start = fline_pt$COMID, 
+                                                mode = "DM", 
+                                                network = flines, 
+                                                distance_km = 1000)
+  
+  # for all flowlines downstream of point, sample linestring every 1 m, 
+  # suppressing warnings about repeated attributes for sub-geometries
+  fline_pts <- flines_down |>
+    sf::st_segmentize(dfMaxLength = units::as_units(1, "m")) |>
+    sf::st_cast("LINESTRING") |>
+    sf::st_cast("POINT") |>
+    arrange(desc(hydroseq)) |>
+    suppressWarnings() 
+  
+  # find the flowline node that is closest to the pt 
+  fline_nn_idx <- sf::st_nearest_feature(pt, fline_pts)
+  
+  # split the flowline at the nearest node and return downstream trace
+  downstr_trace <- fline_pts[c(fline_nn_idx:nrow(fline_pts)),] |>
+    group_by(comid) |>
+    summarize(do_union = FALSE) |>
+    sf::st_cast("LINESTRING") |>
+    ungroup()
+  
+  # return length of downstream trace in km
+  dist_m <- as.numeric(sum(sf::st_length(downstr_trace)))
+  dist_km <- round((dist_m/1000), 2)
+  
+  return(dist_km)
+}
+

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -71,23 +71,25 @@ p3_targets_list <- list(
                                 "3_visualize/out/nhdv2_static_attr_summary.csv"),
     format = "file"
   ),
-    # Save png map of site locations
-    tar_target(
-    p3_site_map_png,
-    map_sites(flowlines = p1_nhd_reaches_sf,
-              matched_sites = p2a_site_splits,
-              out_file = "3_visualize/out/do_site_map.png")
-  ),
-      # Save json map of site locations
+  
+  # Save png map of site locations
   tar_target(
-    p3_well_observed_site_data_json,
-        {
-              filename = "3_visualize/out/well_observed_trn_val_test.geojson"
-              sf::st_write(p2a_site_splits, filename, append = FALSE, delete_dsn = TRUE,
-                                              driver = "GeoJSON", quiet = TRUE)
-              filename
-            },
-                format = "file"
+  p3_site_map_png,
+  map_sites(flowlines = p1_nhd_reaches_sf,
+            matched_sites = p2a_site_splits,
+            out_file = "3_visualize/out/do_site_map.png")
+  ),
+  
+  # Save json map of site locations
+  tar_target(
+  p3_well_observed_site_data_json,
+  {
+    filename = "3_visualize/out/well_observed_trn_val_test.geojson"
+    sf::st_write(p2a_site_splits, filename, append = FALSE, delete_dsn = TRUE,
+                 driver = "GeoJSON", quiet = TRUE)
+    filename
+    },
+  format = "file"
   )
 
 )

--- a/3_visualize/src/map_sites.R
+++ b/3_visualize/src/map_sites.R
@@ -25,8 +25,6 @@
 #' @param lon_breaks numeric sequence indicating the breaks to use when plotting
 #' longitude. By default, includes lon_breaks that are focused on the lower 
 #' Delaware River Basin.
-#' @param site_type_colors vector of character strings indicating the colors to use
-#' when plotting train, validation, and test sites.
 #' @param fig_width_inches numeric value indicating the width of the saved figure
 #' in inches
 #' @param fig_height_inches numeric value indicating the height of the saved figure
@@ -40,11 +38,9 @@ map_sites <- function(flowlines,
                       out_file,
                       huc6_select = "020402", 
                       basin_bbox = c(xmin = -76.39556, ymin = 39.5, xmax = -74.37121, ymax = 40.89106),
-                      epsg_out = 3857, 
+                      epsg_out = 4269, 
                       lat_breaks = seq(from = 39.6, to = 41, by = 0.4),
                       lon_breaks = seq(from = -74.5, to = -76.5, by = -0.5),
-                      site_type_colors = c("#E69F00","#56B4E9","#0072B2","#009E73"),
-                      site_type_names = c("train","validation","train/val","test"),
                       fig_width_inches = 7.8, fig_height_inches = 6.5){
   
   # Create bbox/spatial extent of sites used in the model
@@ -52,7 +48,8 @@ map_sites <- function(flowlines,
     sf::st_as_sfc() %>%
     sf::st_set_crs(4326) %>%
     sf::st_as_sf() %>%
-    sf::st_transform(crs = epsg_out)
+    sf::st_transform(crs = epsg_out) %>%
+    suppressMessages()
   
   # Download HUC12 boundaries and dissolve them to get HUC6 boundaries
   # corresponding with the watershed of interest
@@ -63,7 +60,8 @@ map_sites <- function(flowlines,
     sf::st_as_sf() %>%
     sf::st_transform(crs = epsg_out) %>%
     # crop the watershed to the matched_sites bounding box
-    sf::st_crop(subset_bbox) 
+    sf::st_crop(subset_bbox) %>%
+    suppressMessages()
 
   # Subset the flowlines that should be mapped within the basin boundary
   flowlines_in_basin <- flowlines %>%
@@ -75,24 +73,72 @@ map_sites <- function(flowlines,
     sf::st_crop(subset_bbox) %>% 
     # ignore warnings about attribute variables assumed spatially constant
     suppressWarnings() %>%
+    suppressMessages() %>%
     # make sure that all flowlines have a positive stream order
     filter(STREAMORDE > 0) 
-    
+  
+  # Manually format map labels (monitoring sites and Philadelphia, PA)
+  matched_sites_fmt <- matched_sites %>%
+    mutate(hJust = case_when(site_name_abbr == "FC" ~ 1.4,
+                             site_name_abbr == "BAP" ~ -0.2,
+                             site_name_abbr %in% c("SR_72", "SR_40.2") ~ -0.15,
+                             site_name_abbr %in% c("CC_12.3", "CC_4.1") ~ 1.2,
+                             site_name_abbr %in% c("BC_7.6", "BC_23.6") ~ -0.15,
+                             site_name_abbr == "BC_40" ~ 0.30,
+                             site_name_abbr == "BC_53.2" ~ 1.15,
+                             TRUE ~ 0),
+           vJust = case_when(site_name_abbr == "FC" ~ 1,
+                             site_name_abbr == "BAP" ~ -0.3,
+                             site_name_abbr == "CC_12.3" ~ 0.35,
+                             site_name_abbr == "CC_4.1" ~ 0.5,
+                             site_name_abbr == "BC_40" ~ -0.5,
+                             site_name_abbr == "BC_53.2" ~ 0.25,
+                             site_name_abbr %in% c("BC_7.6", "BC_23.6") ~ 0.3,
+                             TRUE ~ 0))
+
+  phl_pt <- tibble(name = "Philadelphia", lon = -75.1803056, lat = 39.95663889,
+                   hJust = -0.05, vJust = 0.3)
+  phl_pt_sf <- sf::st_as_sf(phl_pt, coords = c("lon", "lat"), crs = 4326, remove = FALSE)
+  
+  # Download and format 2019 impervious cover data to use as a base map
+  impv_2019 <- FedData::get_nlcd(template = subset_bbox,
+                                 label = "ldrb",
+                                 year = 2019,
+                                 dataset = 'impervious',
+                                 extraction.dir = tempdir(),
+                                 force.redo = TRUE)
+  r1 <- raster::projectRaster(impv_2019, crs = epsg_out)
+  
+  r2 <- raster::crop(r1, basin_boundary)
+  r3 <- raster::mask(r2, basin_boundary)
+  impv_spdf <- as(r3, "SpatialPixelsDataFrame")
+  impv_df <- as.data.frame(impv_spdf)
+  colnames(impv_df) <- c("value", "x", "y")
+  
   # Create site map
   sites_map <- ggplot() + 
-    geom_sf(data = basin_boundary, fill = 'gray80', color = NA, alpha = .6) +
+    geom_sf(data = basin_boundary, fill = 'gray80', color = NA, alpha = 0.6) +
+    geom_tile(data = impv_df, aes(x = x, y = y, fill = value), alpha = 0.7) +
+    scale_fill_gradient(low = "gray", high = "brown", guide = "none") + 
     # adjust line width so that flow direction is more intuitive
-    geom_sf(data = flowlines_in_basin, aes(size = STREAMORDE/5), color = "slategray4") +
+    geom_sf(data = flowlines_in_basin, aes(size = STREAMORDE/5), color = "steelblue4") +
     # scale_size_identity needed to provide line width as an aesthetic
     scale_size_identity() +
-    geom_sf(data = matched_sites, aes(color = site_type), size = 3.5) +
-    scale_fill_identity() +
+    geom_sf(data = matched_sites_fmt, color = "black", size = 3) +
+    geom_sf_label(data = matched_sites_fmt, 
+                 aes(label = site_name_abbr, hjust = hJust, vjust = vJust), 
+                 size = 3.5,
+                 label.size  = NA,
+                 alpha = 0.4) +
+    geom_sf(data = phl_pt_sf, color = "black", size = 3, shape = 1) +
+    geom_sf_label(data = phl_pt_sf, 
+                 aes(label = name, hjust = hJust, vjust = vJust), 
+                 size = 5,
+                 label.size = NA,
+                 alpha = 0.1) + 
     coord_sf() +
     scale_y_continuous(breaks = lat_breaks) +
     scale_x_continuous(breaks = lon_breaks) + 
-    scale_color_manual(breaks = site_type_names, 
-                       values = site_type_colors,
-                       name = "Site type")+
     theme_bw() +
     theme(panel.grid.major = element_blank(), 
           panel.grid.minor = element_blank(),
@@ -118,10 +164,16 @@ map_sites <- function(flowlines,
   sites_map2 <- sites_map + theme(legend.position = 'none')
   
   # create and save combined map
-  do_sites_map <- cowplot::ggdraw() + 
-    cowplot::draw_plot(sites_map2) + 
-    cowplot::draw_plot(inset_map, x = 0.66, y = 0.63, width = 0.35, height = 0.35) + 
-    cowplot::draw_plot(legend, x = -0.3, y = -0.2)
+  if(is.null(legend)){
+    do_sites_map <- cowplot::ggdraw() + 
+      cowplot::draw_plot(sites_map2) + 
+      cowplot::draw_plot(inset_map, x = 0.66, y = 0.63, width = 0.35, height = 0.35)
+  } else {
+    do_sites_map <- cowplot::ggdraw() + 
+      cowplot::draw_plot(sites_map2) + 
+      cowplot::draw_plot(inset_map, x = 0.66, y = 0.63, width = 0.35, height = 0.35) + 
+      cowplot::draw_plot(legend, x = -0.3, y = -0.2)
+  }
 
   ggsave(out_file, 
          plot = do_sites_map,
@@ -130,7 +182,6 @@ map_sites <- function(flowlines,
   
   # return save directory
   return(out_file)
-
 }
 
 

--- a/3_visualize/src/map_sites.R
+++ b/3_visualize/src/map_sites.R
@@ -80,20 +80,20 @@ map_sites <- function(flowlines,
   # Manually format map labels (monitoring sites and Philadelphia, PA)
   matched_sites_fmt <- matched_sites %>%
     mutate(hJust = case_when(site_name_abbr == "FC" ~ 1.4,
-                             site_name_abbr == "BAP" ~ -0.2,
-                             site_name_abbr %in% c("SR_72", "SR_40.2") ~ -0.15,
-                             site_name_abbr %in% c("CC_12.3", "CC_4.1") ~ 1.2,
-                             site_name_abbr %in% c("BC_7.6", "BC_23.6") ~ -0.15,
+                             site_name_abbr == "BAP" ~ 0.4,
+                             site_name_abbr %in% c("SR_72", "SR_40") ~ -0.15,
+                             site_name_abbr %in% c("CC_12", "CC_4") ~ 1.2,
+                             site_name_abbr %in% c("BC_8", "BC_24") ~ -0.15,
                              site_name_abbr == "BC_40" ~ 0.30,
-                             site_name_abbr == "BC_53.2" ~ 1.15,
+                             site_name_abbr == "BC_53" ~ 1.15,
                              TRUE ~ 0),
            vJust = case_when(site_name_abbr == "FC" ~ 1,
                              site_name_abbr == "BAP" ~ -0.3,
-                             site_name_abbr == "CC_12.3" ~ 0.35,
-                             site_name_abbr == "CC_4.1" ~ 0.5,
+                             site_name_abbr == "CC_12" ~ 0.35,
+                             site_name_abbr == "CC_4" ~ 0.5,
                              site_name_abbr == "BC_40" ~ -0.5,
-                             site_name_abbr == "BC_53.2" ~ 0.25,
-                             site_name_abbr %in% c("BC_7.6", "BC_23.6") ~ 0.3,
+                             site_name_abbr == "BC_53" ~ 0.25,
+                             site_name_abbr %in% c("BC_8", "BC_24") ~ 0.3,
                              TRUE ~ 0))
 
   phl_pt <- tibble(name = "Philadelphia", lon = -75.1803056, lat = 39.95663889,
@@ -108,7 +108,6 @@ map_sites <- function(flowlines,
                                  extraction.dir = tempdir(),
                                  force.redo = TRUE)
   r1 <- raster::projectRaster(impv_2019, crs = epsg_out)
-  
   r2 <- raster::crop(r1, basin_boundary)
   r3 <- raster::mask(r2, basin_boundary)
   impv_spdf <- as(r3, "SpatialPixelsDataFrame")

--- a/3_visualize/src/map_sites.R
+++ b/3_visualize/src/map_sites.R
@@ -79,22 +79,24 @@ map_sites <- function(flowlines,
   
   # Manually format map labels (monitoring sites and Philadelphia, PA)
   matched_sites_fmt <- matched_sites %>%
-    mutate(hJust = case_when(site_name_abbr == "FC" ~ 1.4,
-                             site_name_abbr == "BAP" ~ 0.4,
+    mutate(hJust = case_when(site_name_abbr == "FC" ~ 0.65,
+                             site_name_abbr == "BAP" ~ 0.2,
                              site_name_abbr %in% c("SR_72", "SR_40") ~ -0.15,
                              site_name_abbr %in% c("CC_12", "CC_4") ~ 1.2,
                              site_name_abbr %in% c("BC_8", "BC_24") ~ -0.15,
                              site_name_abbr == "BC_40" ~ 0.30,
                              site_name_abbr == "BC_53" ~ 1.15,
                              TRUE ~ 0),
-           vJust = case_when(site_name_abbr == "FC" ~ 1,
-                             site_name_abbr == "BAP" ~ -0.3,
+           vJust = case_when(site_name_abbr == "FC" ~ 2,
+                             site_name_abbr == "BAP" ~ -0.7,
                              site_name_abbr == "CC_12" ~ 0.35,
                              site_name_abbr == "CC_4" ~ 0.5,
                              site_name_abbr == "BC_40" ~ -0.5,
                              site_name_abbr == "BC_53" ~ 0.25,
                              site_name_abbr %in% c("BC_8", "BC_24") ~ 0.3,
-                             TRUE ~ 0))
+                             TRUE ~ 0),
+           X = sf::st_coordinates(.)[,1],
+           Y = sf::st_coordinates(.)[,2])
 
   phl_pt <- tibble(name = "Philadelphia", lon = -75.1803056, lat = 39.95663889,
                    hJust = -0.05, vJust = 0.3)
@@ -129,6 +131,12 @@ map_sites <- function(flowlines,
                  size = 3.5,
                  label.size  = NA,
                  alpha = 0.4) +
+    geom_segment(data = filter(matched_sites_fmt, site_name_abbr == "BAP"),
+                 aes(x = X + 0.04, xend = X + 0.01, y = Y + 0.04, yend = Y + 0.01),
+                 color = "black", arrow = arrow(length = unit(1.5, "mm"))) +
+    geom_segment(data = filter(matched_sites_fmt, site_name_abbr == "FC"),
+                 aes(x = X - 0.015, xend = X - 0.01, y = Y - 0.05, yend = Y - 0.01),
+                 color = "black", arrow = arrow(length = unit(1.5, "mm"))) +
     geom_sf(data = phl_pt_sf, color = "black", size = 3, shape = 1) +
     geom_sf_label(data = phl_pt_sf, 
                  aes(label = name, hjust = hJust, vjust = vJust), 

--- a/3_visualize/src/map_sites.R
+++ b/3_visualize/src/map_sites.R
@@ -118,9 +118,16 @@ map_sites <- function(flowlines,
   
   # Create site map
   sites_map <- ggplot() + 
-    geom_sf(data = basin_boundary, fill = 'gray80', color = NA, alpha = 0.6) +
-    geom_tile(data = impv_df, aes(x = x, y = y, fill = value), alpha = 0.7) +
-    scale_fill_gradient(low = "gray", high = "brown", guide = "none") + 
+    geom_sf(data = basin_boundary, fill = 'gray80', color = NA, alpha = 0.4) +
+    geom_tile(data = impv_df, aes(x = x, y = y, fill = value)) +
+    #scale_fill_gradient(low = "gray", high = "brown", guide = "none") + 
+    scale_fill_gradient(low = "#EBEAEA", high = "#B75555", na.value = "#EBEAEA",
+                        name = "Impervious cover (%)",
+                        limits = c(0,100), breaks = c(0, 100)) +
+    guides(fill = guide_colourbar(ticks = FALSE, direction = "horizontal",
+                                  title.position = "top", title.hjust = 0.5,
+                                  barheight = 0.55, barwidth = 7.5,
+                                  available_aes = "fill")) + 
     # adjust line width so that flow direction is more intuitive
     geom_sf(data = flowlines_in_basin, aes(size = STREAMORDE/5), color = "steelblue4") +
     # scale_size_identity needed to provide line width as an aesthetic
@@ -149,7 +156,9 @@ map_sites <- function(flowlines,
     theme_bw() +
     theme(panel.grid.major = element_blank(), 
           panel.grid.minor = element_blank(),
-          axis.title = element_blank()) +
+          axis.title = element_blank(),
+          legend.title = element_text(size = 10),
+          legend.text = element_text(size = 8.5)) +
     ggspatial::annotation_north_arrow(
       location = "br", which_north = "true",
       pad_x = unit(1, 'cm'), pad_y = unit(0.5, 'cm'),
@@ -179,7 +188,7 @@ map_sites <- function(flowlines,
     do_sites_map <- cowplot::ggdraw() + 
       cowplot::draw_plot(sites_map2) + 
       cowplot::draw_plot(inset_map, x = 0.66, y = 0.63, width = 0.35, height = 0.35) + 
-      cowplot::draw_plot(legend, x = -0.3, y = -0.2)
+      cowplot::draw_plot(legend, x = -0.295, y = -0.35)
   }
 
   ggsave(out_file, 


### PR DESCRIPTION
This PR includes code changes to make the following edits to the site map: 

- filter to the new set of 10 sites
- label Philadelphia
- add a base map to indicate urban areas/areas with high development
- label the sites with a site identifier

The base map is the 2019 NLCD impervious cover layer. To me this seemed like a nice way to show relative levels of urban density and still keep the base layer relatively simple. Note that this requires two new dependencies that are not in our dockerfile, {FedData} and {raster}. I'm not sure if it's possible to add these R libraries without updating the versions of any of the other libraries. I'm a little wary of updating the other packages at this stage so if that's not possible, maybe we consider taking this map out of the pipeline.

Regarding the site labels, I re-read the manuscript draft and what stood out to me as the biggest differentiator between sites was whether a site was located along the Schuylkill River or Brandywine Creek (the temporal holdout sites). I therefore opted to include site labels, including "SR" for the Schuylkill and "BC" for Brandywine. The number refers to the river mile (actually, river km) from the outlet and so can provide some information about river size if the site id is used in any of the other figures. What do you think?

![edited_map](https://github.com/USGS-R/drb-do-ml/assets/8785034/4f0fbbc6-0b83-4c8c-95b1-22e60c7ed82b)

Draft caption text: 

> Figure 2. Monitoring sites used to train and test deep learning models that predict daily dissolved oxygen concentration in the lower Delaware River Basin, USA. Several sites are distributed along two tributaries to the Delaware River, Brandywine Creek (BC, n = 4) and the Schuylkill River (SR, n = 2). Two sites are located along Cobbs Creek in Philadelphia, PA (CC) and two sites are located along relatively forested, headwater streams in the northwest portion of the basin (Baptism Creek, BAP; French Creek, FC). Numbers within the site labels indicate the river distance (km) between the site and the river outlet. Red shading shows urban imperviousness, where darker shading indicates a higher percentage of urban impervious surface cover within a 30-m land surface pixel (NLCD 2019). 

Closes #209